### PR TITLE
Fix self-referencing VAR_* dashboard constants (LOTC-1302)

### DIFF
--- a/scripts/configurator/dashboard_fixer.py
+++ b/scripts/configurator/dashboard_fixer.py
@@ -138,7 +138,7 @@ def _fix_template_variables(dashboard, dinfo, inputs_map, config, state):
         query = var.get("query", "")
 
         # Check if this is a summary reference via ${VAR_*} pattern
-        var_ref_match = re.match(r"^\$\{(VAR_[A-Z_]+)\}$", query)
+        var_ref_match = re.match(r"^\$\{(VAR_[A-Z0-9_]+)\}$", query)
 
         if var_name == "raw_table":
             has_raw_table = True
@@ -161,8 +161,30 @@ def _fix_template_variables(dashboard, dinfo, inputs_map, config, state):
             continue
 
         if var_ref_match and var_type == "constant":
-            # This is a summary variable reference like ${VAR_SUMMARY_HOUR}
             var_ref_name = var_ref_match.group(1)
+
+            # Check if self-referencing: e.g. variable "table" with query "${VAR_TABLE}"
+            stripped_name = var_ref_name[4:]  # Remove "VAR_" prefix
+            if stripped_name.upper() == var_name.upper():
+                # Self-referencing VAR_* constant — resolve to table placeholder
+                # (timestamp is excluded here; handled separately in LOTC-1303)
+                if var_name.lower() != "timestamp":
+                    table_value = "__PROJECT_NAME__.__TABLE_NAME__"
+                    var["query"] = table_value
+                    var["current"] = {
+                        "selected": False,
+                        "text": table_value,
+                        "value": table_value,
+                    }
+                    var["options"] = [{
+                        "selected": False,
+                        "text": table_value,
+                        "value": table_value,
+                    }]
+                new_var_list.append(var)
+                continue
+
+            # This is a summary variable reference like ${VAR_SUMMARY_HOUR}
             label = inputs_map.get(var_ref_name, var_name)
 
             # Find matching summary by label/name

--- a/tests/test_dashboard_fixer.py
+++ b/tests/test_dashboard_fixer.py
@@ -1,0 +1,221 @@
+"""Tests for dashboard_fixer module — fixing self-referencing VAR_* template variables."""
+
+import sys
+import types
+
+import pytest
+
+# Stub out utils.file_utils before importing dashboard_fixer, since the module
+# lives under scripts/ and isn't on sys.path at the repo root level.
+_utils_pkg = types.ModuleType("utils")
+_utils_pkg.file_utils = types.ModuleType("utils.file_utils")
+_utils_pkg.file_utils.read_json = lambda *a, **kw: {}
+_utils_pkg.file_utils.write_json = lambda *a, **kw: None
+sys.modules.setdefault("utils", _utils_pkg)
+sys.modules.setdefault("utils.file_utils", _utils_pkg.file_utils)
+
+from scripts.configurator.config import BundleConfig, BundleState, DashboardInfo
+from scripts.configurator.dashboard_fixer import _fix_template_variables
+
+
+def _make_config(tmp_path):
+    """Create a minimal BundleConfig for testing."""
+    bundle_dir = tmp_path / "trafficpeak" / "test_bundle"
+    bundle_dir.mkdir(parents=True)
+    return BundleConfig(
+        bundle_dir=str(bundle_dir),
+        table_name="test_table",
+        data_category="cdn",
+    )
+
+
+def _make_var(name, query, var_type="constant"):
+    """Create a Grafana template variable dict with self-referencing structure."""
+    return {
+        "hide": 2,
+        "name": name,
+        "query": query,
+        "skipUrlSync": True,
+        "type": var_type,
+        "current": {
+            "selected": False,
+            "text": query,
+            "value": query,
+        },
+        "options": [
+            {
+                "selected": False,
+                "text": query,
+                "value": query,
+            }
+        ],
+    }
+
+
+class TestSelfReferencingVarFix:
+    """Tests for self-referencing VAR_* constant resolution in _fix_template_variables."""
+
+    def test_table_var_resolved(self, tmp_path):
+        """Variable 'table' with query '${VAR_TABLE}' is resolved to __PROJECT_NAME__.__TABLE_NAME__."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("table", "${VAR_TABLE}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        expected = "__PROJECT_NAME__.__TABLE_NAME__"
+        assert var["query"] == expected
+        assert var["current"]["value"] == expected
+        assert var["current"]["text"] == expected
+        assert var["options"][0]["value"] == expected
+        assert var["options"][0]["text"] == expected
+
+    def test_logs_var_resolved(self, tmp_path):
+        """Variable 'logs' with query '${VAR_LOGS}' is resolved to table placeholder."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("logs", "${VAR_LOGS}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+
+    def test_ds2_var_resolved(self, tmp_path):
+        """Variable 'ds2' with query '${VAR_DS2}' is resolved to table placeholder."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("ds2", "${VAR_DS2}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+
+    def test_timestamp_var_not_resolved(self, tmp_path):
+        """Variable 'timestamp' with query '${VAR_TIMESTAMP}' is left untouched (LOTC-1303)."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("timestamp", "${VAR_TIMESTAMP}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "${VAR_TIMESTAMP}"
+        assert var["current"]["value"] == "${VAR_TIMESTAMP}"
+
+    def test_non_self_referencing_var_not_touched(self, tmp_path):
+        """A VAR_* reference that does NOT match the variable's own name is not treated
+        as self-referencing (falls through to summary matching)."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("my_summary", "${VAR_SUMMARY_HOUR}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        # No matching summary in state, so query should remain unchanged
+        assert var["query"] == "${VAR_SUMMARY_HOUR}"
+
+    def test_case_insensitive_match(self, tmp_path):
+        """Self-referencing detection is case-insensitive: 'treemapCells' matches VAR_TREEMAPCELLS."""
+        dashboard = {
+            "templating": {
+                "list": [_make_var("treemapCells", "${VAR_TREEMAPCELLS}")]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+
+    def test_non_constant_type_not_affected(self, tmp_path):
+        """A self-referencing pattern in a non-constant variable type is not touched."""
+        var = _make_var("table", "${VAR_TABLE}", var_type="query")
+        dashboard = {"templating": {"list": [var]}}
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        assert dashboard["templating"]["list"][0]["query"] == "${VAR_TABLE}"
+
+    def test_raw_table_still_injected(self, tmp_path):
+        """raw_table injection still works alongside self-referencing fix."""
+        dashboard = {
+            "templating": {
+                "list": [
+                    _make_var("table", "${VAR_TABLE}"),
+                    _make_var("raw_table", "some_old_value"),
+                ]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var_list = dashboard["templating"]["list"]
+        table_var = next(v for v in var_list if v["name"] == "table")
+        raw_table_var = next(v for v in var_list if v["name"] == "raw_table")
+
+        assert table_var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+        assert raw_table_var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+
+    def test_multiple_self_referencing_vars(self, tmp_path):
+        """Multiple self-referencing vars in one dashboard are all resolved."""
+        dashboard = {
+            "templating": {
+                "list": [
+                    _make_var("table", "${VAR_TABLE}"),
+                    _make_var("ds2", "${VAR_DS2}"),
+                    _make_var("timestamp", "${VAR_TIMESTAMP}"),
+                ]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/path.json", is_primary=True)
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var_list = dashboard["templating"]["list"]
+        table_var = next(v for v in var_list if v["name"] == "table")
+        ds2_var = next(v for v in var_list if v["name"] == "ds2")
+        ts_var = next(v for v in var_list if v["name"] == "timestamp")
+
+        assert table_var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+        assert ds2_var["query"] == "__PROJECT_NAME__.__TABLE_NAME__"
+        assert ts_var["query"] == "${VAR_TIMESTAMP}"  # Untouched


### PR DESCRIPTION
## Summary
- Detects constant-type template variables where the query self-references the variable's own name (e.g. variable `table` with query `${VAR_TABLE}`) and resolves them to `__PROJECT_NAME__.__TABLE_NAME__`
- Widens the `${VAR_*}` regex to include digits so names like `VAR_DS2` are matched
- Excludes `timestamp` variables (handled separately in LOTC-1303)

## Test plan
- [x] 9 new unit tests covering: table/logs/ds2 resolution, timestamp exclusion, non-self-referencing passthrough, case-insensitive matching, non-constant types unaffected, raw_table coexistence, multiple vars
- [x] All 29 tests pass (9 new + 20 existing)
- [x] Verified locally against `trafficpeak/security/0.9.0` — all `${VAR_TABLE}`, `${VAR_DS2}`, `${VAR_TREEMAPCELLS}` replaced with `__PROJECT_NAME__.__TABLE_NAME__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)