### PR TITLE
LOTC-1303: Auto-fix self-referencing VAR_TIMESTAMP constants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
+pythonpath = [".", "scripts"]

--- a/scripts/configurator/dashboard_fixer.py
+++ b/scripts/configurator/dashboard_fixer.py
@@ -160,6 +160,31 @@ def _fix_template_variables(dashboard, dinfo, inputs_map, config, state):
             new_var_list.append(var)
             continue
 
+        # Check for self-referencing VAR_TIMESTAMP constant
+        if (
+            var_ref_match
+            and var_type == "constant"
+            and var_name.lower() == "timestamp"
+            and var_ref_match.group(1) == "VAR_TIMESTAMP"
+        ):
+            ts_col = _get_primary_timestamp_column(config, state)
+            if ts_col:
+                var["query"] = ts_col
+                var["current"] = {
+                    "selected": False,
+                    "text": ts_col,
+                    "value": ts_col,
+                }
+                var["options"] = [{
+                    "selected": False,
+                    "text": ts_col,
+                    "value": ts_col,
+                }]
+                var["hide"] = 2
+                var["skipUrlSync"] = True
+            new_var_list.append(var)
+            continue
+
         if var_ref_match and var_type == "constant":
             # This is a summary variable reference like ${VAR_SUMMARY_HOUR}
             var_ref_name = var_ref_match.group(1)
@@ -220,6 +245,35 @@ def _fix_template_variables(dashboard, dinfo, inputs_map, config, state):
 
     templating["list"] = new_var_list
     dashboard["templating"] = templating
+
+
+def _get_primary_timestamp_column(config, state):
+    """Read the first transform and return the name of the primary timestamp column.
+
+    Walks settings.output_columns to find the column with datatype.primary == True.
+    Returns the column name (e.g. "reqTimeSec", "timestamp"), or None if not found.
+    """
+    if not state.transforms:
+        return None
+
+    tinfo = state.transforms[0]
+    read_path = tinfo.final_path
+    if config.dry_run:
+        read_path = tinfo.original_path
+
+    if not read_path or not os.path.isfile(read_path):
+        return None
+
+    data = read_json(read_path)
+    settings = data.get("settings", {})
+    output_columns = settings.get("output_columns", [])
+
+    for col in output_columns:
+        datatype = col.get("datatype", {})
+        if datatype.get("primary") is True:
+            return col.get("name")
+
+    return None
 
 
 def _find_summary_var(label, state):

--- a/tests/manual_test_var_timestamp.py
+++ b/tests/manual_test_var_timestamp.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Manual test: inject ${VAR_TIMESTAMP} into a temp copy of mcdn and run the dashboard fixer.
+
+Usage:
+    python3 tests/manual_test_var_timestamp.py
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+# Add repo root and scripts/ to path for imports
+repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, repo_dir)
+sys.path.insert(0, os.path.join(repo_dir, "scripts"))
+
+from scripts.configurator.config import BundleConfig, BundleState, DashboardInfo, TransformInfo
+from scripts.configurator.dashboard_fixer import _fix_template_variables, _get_primary_timestamp_column
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+MCDN_BUNDLE = os.path.join(REPO_ROOT, "trafficpeak", "mcdn", "1.0.0")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        # Copy the mcdn transform so we can read the primary column
+        src_transform = os.path.join(MCDN_BUNDLE, "transformations", "transform.json")
+        if not os.path.isfile(src_transform):
+            # Try default_shared fallback
+            src_transform = os.path.join(
+                REPO_ROOT, "trafficpeak", "default_shared", "transformations", "transform.json"
+            )
+
+        dst_transform = os.path.join(tmp, "transformations", "transform.json")
+        os.makedirs(os.path.dirname(dst_transform), exist_ok=True)
+        shutil.copy2(src_transform, dst_transform)
+
+        # Read the transform to show what primary column we expect
+        with open(dst_transform) as f:
+            transform_data = json.load(f)
+        for col in transform_data["settings"]["output_columns"]:
+            if col.get("datatype", {}).get("primary") is True:
+                expected_col = col["name"]
+                break
+        else:
+            print("ERROR: No primary column found in transform!")
+            return 1
+
+        print(f"Transform primary column: {expected_col}")
+        print()
+
+        # Build a fake dashboard with ${VAR_TIMESTAMP}
+        dashboard = {
+            "templating": {
+                "list": [
+                    {
+                        "name": "raw_table",
+                        "type": "constant",
+                        "query": "${VAR_SIEM}",
+                        "current": {"selected": False, "text": "${VAR_SIEM}", "value": "${VAR_SIEM}"},
+                        "options": [{"selected": False, "text": "${VAR_SIEM}", "value": "${VAR_SIEM}"}],
+                    },
+                    {
+                        "name": "timestamp",
+                        "type": "constant",
+                        "query": "${VAR_TIMESTAMP}",
+                        "current": {"selected": False, "text": "${VAR_TIMESTAMP}", "value": "${VAR_TIMESTAMP}"},
+                        "options": [{"selected": False, "text": "${VAR_TIMESTAMP}", "value": "${VAR_TIMESTAMP}"}],
+                    },
+                    {
+                        "name": "interval",
+                        "type": "interval",
+                        "query": "1m,5m,15m,30m,1h,6h,12h,1d,7d",
+                    },
+                ]
+            }
+        }
+
+        print("BEFORE:")
+        for var in dashboard["templating"]["list"]:
+            print(f"  {var['name']:15s} type={var['type']:10s} query={var.get('query', '')}")
+        print()
+
+        # Set up config and state
+        config = BundleConfig(
+            bundle_dir=tmp,
+            table_name="test_table",
+            data_category="web",
+            source_name="trafficpeak",
+            bundle_name="mcdn",
+            verbose=True,
+        )
+
+        tinfo = TransformInfo(original_path=dst_transform)
+        tinfo.final_path = dst_transform
+
+        state = BundleState()
+        state.transforms = [tinfo]
+
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        # Run the fixer
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        print("AFTER:")
+        for var in dashboard["templating"]["list"]:
+            print(f"  {var['name']:15s} type={var['type']:10s} query={var.get('query', '')}")
+        print()
+
+        # Check timestamp was resolved
+        ts_var = next(v for v in dashboard["templating"]["list"] if v["name"] == "timestamp")
+        if ts_var["query"] == expected_col:
+            print(f"SUCCESS: timestamp resolved to '{expected_col}'")
+            return 0
+        else:
+            print(f"FAIL: timestamp query is '{ts_var['query']}', expected '{expected_col}'")
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dashboard_fixer.py
+++ b/tests/test_dashboard_fixer.py
@@ -1,0 +1,246 @@
+"""Tests for dashboard_fixer module — VAR_TIMESTAMP self-referencing constant fix."""
+
+import json
+import os
+
+import pytest
+
+from scripts.configurator.config import BundleConfig, BundleState, DashboardInfo, TransformInfo
+from scripts.configurator.dashboard_fixer import _fix_template_variables, _get_primary_timestamp_column
+
+
+def _make_transform_json(tmp_path, primary_col_name="reqTimeSec"):
+    """Create a minimal transform.json with a primary timestamp column."""
+    transform_data = {
+        "name": "test_transform",
+        "settings": {
+            "output_columns": [
+                {
+                    "name": "version",
+                    "datatype": {"type": "uint8", "primary": False},
+                },
+                {
+                    "name": primary_col_name,
+                    "datatype": {
+                        "type": "epoch",
+                        "primary": True,
+                        "format": "s",
+                        "resolution": "ms",
+                    },
+                },
+                {
+                    "name": "statusCode",
+                    "datatype": {"type": "uint16", "primary": False},
+                },
+            ],
+        },
+    }
+    transform_path = tmp_path / "transformations" / "transform.json"
+    transform_path.parent.mkdir(parents=True, exist_ok=True)
+    transform_path.write_text(json.dumps(transform_data))
+    return str(transform_path)
+
+
+def _make_config(tmp_path, dry_run=False):
+    """Create a minimal BundleConfig."""
+    config = BundleConfig(
+        bundle_dir=str(tmp_path),
+        table_name="test_table",
+        data_category="web",
+        source_name="test",
+        bundle_name="test_bundle",
+    )
+    config.dry_run = dry_run
+    config.verbose = False
+    return config
+
+
+def _make_state(transform_path):
+    """Create a BundleState with one transform."""
+    tinfo = TransformInfo(original_path=transform_path)
+    tinfo.final_path = transform_path
+    state = BundleState()
+    state.transforms = [tinfo]
+    return state
+
+
+class TestGetPrimaryTimestampColumn:
+    """Tests for _get_primary_timestamp_column helper."""
+
+    def test_returns_primary_column_name(self, tmp_path):
+        """Should return the name of the column with datatype.primary == True."""
+        transform_path = _make_transform_json(tmp_path, "reqTimeSec")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        result = _get_primary_timestamp_column(config, state)
+        assert result == "reqTimeSec"
+
+    def test_returns_timestamp_column(self, tmp_path):
+        """Should work when the primary column is named 'timestamp'."""
+        transform_path = _make_transform_json(tmp_path, "timestamp")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        result = _get_primary_timestamp_column(config, state)
+        assert result == "timestamp"
+
+    def test_returns_none_when_no_transforms(self, tmp_path):
+        """Should return None when state has no transforms."""
+        config = _make_config(tmp_path)
+        state = BundleState()
+
+        result = _get_primary_timestamp_column(config, state)
+        assert result is None
+
+    def test_returns_none_when_no_primary(self, tmp_path):
+        """Should return None when no column has primary == True."""
+        transform_data = {
+            "name": "test",
+            "settings": {
+                "output_columns": [
+                    {"name": "col1", "datatype": {"type": "string", "primary": False}},
+                ],
+            },
+        }
+        transform_path = tmp_path / "transform.json"
+        transform_path.write_text(json.dumps(transform_data))
+
+        config = _make_config(tmp_path)
+        state = _make_state(str(transform_path))
+
+        result = _get_primary_timestamp_column(config, state)
+        assert result is None
+
+    def test_dry_run_reads_original_path(self, tmp_path):
+        """In dry_run mode, should read from original_path instead of final_path."""
+        transform_path = _make_transform_json(tmp_path, "reqTimeSec")
+        config = _make_config(tmp_path, dry_run=True)
+
+        tinfo = TransformInfo(original_path=transform_path)
+        tinfo.final_path = "/nonexistent/path/transform.json"
+        state = BundleState()
+        state.transforms = [tinfo]
+
+        result = _get_primary_timestamp_column(config, state)
+        assert result == "reqTimeSec"
+
+
+class TestFixVarTimestamp:
+    """Tests for VAR_TIMESTAMP self-referencing constant detection and fix."""
+
+    def _make_dashboard_with_timestamp_var(self, query="${VAR_TIMESTAMP}", var_name="timestamp"):
+        """Create a minimal dashboard dict with a timestamp template variable."""
+        return {
+            "templating": {
+                "list": [
+                    {
+                        "name": var_name,
+                        "type": "constant",
+                        "query": query,
+                        "current": {
+                            "selected": False,
+                            "text": query,
+                            "value": query,
+                        },
+                        "options": [{
+                            "selected": False,
+                            "text": query,
+                            "value": query,
+                        }],
+                    }
+                ]
+            }
+        }
+
+    def test_self_referencing_timestamp_resolved(self, tmp_path):
+        """A constant named 'timestamp' with query '${VAR_TIMESTAMP}' should be
+        resolved to the primary timestamp column from the transform."""
+        transform_path = _make_transform_json(tmp_path, "reqTimeSec")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        dashboard = self._make_dashboard_with_timestamp_var()
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "reqTimeSec"
+        assert var["current"]["value"] == "reqTimeSec"
+        assert var["current"]["text"] == "reqTimeSec"
+        assert var["options"][0]["value"] == "reqTimeSec"
+        assert var["hide"] == 2
+        assert var["skipUrlSync"] is True
+
+    def test_resolves_to_different_primary_column(self, tmp_path):
+        """When the transform's primary column is 'timestamp' (not 'reqTimeSec'),
+        the variable should resolve to 'timestamp'."""
+        transform_path = _make_transform_json(tmp_path, "timestamp")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        dashboard = self._make_dashboard_with_timestamp_var()
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "timestamp"
+
+    def test_non_self_referencing_var_untouched(self, tmp_path):
+        """A constant variable with a ${VAR_*} query that doesn't self-reference
+        should NOT be modified by the timestamp fix."""
+        transform_path = _make_transform_json(tmp_path, "reqTimeSec")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        # Variable named "cdn_panel" with query "${VAR_CDN_PANEL}" — not self-referencing timestamp
+        dashboard = self._make_dashboard_with_timestamp_var(
+            query="${VAR_CDN_PANEL}", var_name="cdn_panel"
+        )
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        # Should remain unchanged (no summary match either, so stays as-is)
+        assert var["query"] == "${VAR_CDN_PANEL}"
+
+    def test_non_constant_timestamp_untouched(self, tmp_path):
+        """A non-constant variable named 'timestamp' should not be modified."""
+        transform_path = _make_transform_json(tmp_path, "reqTimeSec")
+        config = _make_config(tmp_path)
+        state = _make_state(transform_path)
+
+        dashboard = {
+            "templating": {
+                "list": [
+                    {
+                        "name": "timestamp",
+                        "type": "query",
+                        "query": "SELECT DISTINCT timestamp FROM table",
+                    }
+                ]
+            }
+        }
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        assert var["query"] == "SELECT DISTINCT timestamp FROM table"
+
+    def test_no_transform_leaves_var_unchanged(self, tmp_path):
+        """When no transform is available, VAR_TIMESTAMP should be left as-is."""
+        config = _make_config(tmp_path)
+        state = BundleState()  # No transforms
+
+        dashboard = self._make_dashboard_with_timestamp_var()
+        dinfo = DashboardInfo(path="/fake/dashboard.json", is_primary=True)
+
+        _fix_template_variables(dashboard, dinfo, {}, config, state)
+
+        var = dashboard["templating"]["list"][0]
+        # Still appended to list but query unchanged (no primary col found)
+        assert var["query"] == "${VAR_TIMESTAMP}"


### PR DESCRIPTION
## Summary
- Detects constant-type dashboard template variables where name is `timestamp` and query is `${VAR_TIMESTAMP}` (self-referencing)
- Resolves by reading the transform's `settings.output_columns` to find the column with `datatype.primary == true` and using its name (e.g. `reqTimeSec`, `timestamp`)
- Adds `_get_primary_timestamp_column()` helper and inserts detection before the existing summary variable branch in `_fix_template_variables`

## Test plan
- [x] 10 unit tests covering helper + fix (primary col lookup, dry_run, no transforms, non-self-referencing untouched, non-constant untouched, graceful fallback)
- [x] Manual integration test script (`tests/manual_test_var_timestamp.py`) verified against real mcdn transform
- [x] All 30 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)