### PR TITLE
Specify 'Bundle Request' work type in README

### DIFF
--- a/HOW-TO-CONTRIBUTE.md
+++ b/HOW-TO-CONTRIBUTE.md
@@ -6,7 +6,7 @@ This guide outlines the process for external teams to contribute integration ass
 
 ### 1. Create a Jira Ticket
 
-Create a Jira ticket in the **LOTC** project for your integration request.
+Create a Jira ticket in the **LOTC** project for your integration request. Use the "Bundle Request" work type.
 
 **Jira Project**: [LOTC Board](https://hydrolix.atlassian.net/jira/software/projects/LOTC/boards/635)
 


### PR DESCRIPTION
Updated contribution instructions to specify the use of 'Bundle Request' work type for Jira tickets.