### PR TITLE
Remove directory-based versioning from bundle automation (LOTC-1348)

### DIFF
--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -85,51 +85,16 @@ jobs:
             exit 0
           fi
 
-          # Version freeze check: block modifications to non-latest version folders
-          FREEZE_ERRORS=""
-          while IFS= read -r changed_file; do
-            # Extract version segment (3rd path component) if it matches X.Y.Z
-            VERSION_SEG=$(echo "$changed_file" | cut -d'/' -f3)
-            if ! echo "$VERSION_SEG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              continue
-            fi
-
-            # Determine the bundle parent dir (first two path components)
-            BUNDLE_PARENT=$(echo "$changed_file" | cut -d'/' -f1-2)
-
-            # Find the latest version folder under the bundle parent
-            LATEST_VER=$(ls -d "${BUNDLE_PARENT}"/[0-9]*.* 2>/dev/null | sort -V | tail -1 | xargs basename 2>/dev/null)
-            if [ -z "$LATEST_VER" ]; then
-              continue
-            fi
-
-            # If the changed version is NOT the latest, it's frozen
-            if [ "$VERSION_SEG" != "$LATEST_VER" ]; then
-              FREEZE_ERRORS="${FREEZE_ERRORS}\n  - ${changed_file} (version ${VERSION_SEG} is frozen; latest is ${LATEST_VER})"
-            fi
-          done <<< "$(echo "$ALL_PR_FILES" | grep -E '^(aws|trafficpeak)/')"
-
-          if [ -n "$FREEZE_ERRORS" ]; then
-            echo "::error::Version freeze violation: the following files modify frozen (non-latest) version folders:"
-            echo -e "$FREEZE_ERRORS"
-            echo ""
-            echo "Only the latest version folder for each bundle may be modified."
-            echo "To fix: move your changes to the latest version folder, or create a new version."
-            exit 1
-          fi
-
           FULL_DIRS=""
           VALIDATE_DIRS=""
 
           while IFS= read -r dir; do
             [ -z "$dir" ] && continue
 
-            # Resolve the actual bundle dir (flat or versioned)
+            # Resolve the bundle dir (flat structure)
             BUNDLE_DIR=""
             if [ -f "$dir/bundle-config.json" ]; then
               BUNDLE_DIR="$dir"
-            elif LATEST_VER=$(ls -d "$dir"/[0-9]*.* 2>/dev/null | sort -V | tail -1) && [ -f "$LATEST_VER/bundle-config.json" ]; then
-              BUNDLE_DIR="$LATEST_VER"
             fi
 
             # Use detect_track.py to determine which track this bundle should run on

--- a/HOW-TO-CONTRIBUTE.md
+++ b/HOW-TO-CONTRIBUTE.md
@@ -60,35 +60,33 @@ Organize your assets following the bundle structure. Assets should be placed in 
 
 #### Repository Structure
 
-Assets must be placed inside a **version folder** under your project name. Use [semantic versioning](https://semver.org/) (e.g., `1.0.0`) for the folder name.
+Assets are placed directly under your project name — no version subdirectory.
 
 ```
 integration-deployment-templates/
 ├── aws/
 │   └── your-project-name/
-│       └── 1.0.0/                    ← version folder (required)
-│           ├── bundle-config.json    ← required
-│           ├── dashboards/
-│           ├── dictionaries/
-│           ├── functions/
-│           ├── transformations/
-│           └── summaries/
+│       ├── bundle-config.json    ← required
+│       ├── dashboards/
+│       ├── dictionaries/
+│       ├── functions/
+│       ├── transformations/
+│       └── summaries/
 └── trafficpeak/
     └── your-project-name/
-        └── 1.0.0/                    ← version folder (required)
-            ├── bundle-config.json    ← required
-            ├── dashboards/
-            ├── dictionaries/
-            ├── functions/
-            ├── transformations/
-            └── summaries/
+        ├── bundle-config.json    ← required
+        ├── dashboards/
+        ├── dictionaries/
+        ├── functions/
+        ├── transformations/
+        └── summaries/
 ```
 
-For example, if you're contributing a CloudFlare integration under AWS at version 1.0.0, your assets go in `aws/cloudflare/1.0.0/`.
+For example, if you're contributing a CloudFlare integration under AWS, your assets go in `aws/cloudflare/`.
 
 #### `bundle-config.json` (Required)
 
-Every bundle version directory must include a `bundle-config.json` file. This file is used by CI to automatically format, configure, and validate your bundle when you open a PR.
+Every bundle directory must include a `bundle-config.json` file. This file is used by CI to automatically format, configure, and validate your bundle when you open a PR.
 
 **Required fields:**
 
@@ -104,7 +102,7 @@ Every bundle version directory must include a `bundle-config.json` file. This fi
 |-------|-------------|--------|
 | `table_name` | Primary table name. Letters, digits, and underscores only (no dashes). | e.g., `bot_detection`, `cdn_logs`, `siem_logs` |
 | `data_category` | Type of data the integration handles. | `video`, `cdn`, or `security` |
-| `version` | Bundle version. Must match the version folder name. | e.g., `1.0.0`, `1.1.0`, `2.0.0` |
+| `version` | Bundle version ([semantic versioning](https://semver.org/)). Used for CAC formatting. | e.g., `1.0.0`, `1.1.0`, `2.0.0` |
 
 **Optional fields** (override auto-inferred values):
 

--- a/scripts/configurator/config.py
+++ b/scripts/configurator/config.py
@@ -78,8 +78,6 @@ class BundleConfig:
           (same patterns with trailing version)
         """
         parts = self.bundle_dir.rstrip("/").split("/")
-        if parts and is_semver(parts[-1]):
-            parts = parts[:-1]
         # source/folder/subfolder/bundle
         if len(parts) >= 4 and parts[-2] in VALID_SUBFOLDERS.get(parts[-3], ()):
             return parts[-4]
@@ -94,8 +92,6 @@ class BundleConfig:
     def _infer_bundle_name(self):
         """Infer bundle name from directory path."""
         parts = self.bundle_dir.rstrip("/").split("/")
-        if parts and is_semver(parts[-1]):
-            parts = parts[:-1]
         return parts[-1] if parts else "unknown"
 
     @property
@@ -111,12 +107,6 @@ class BundleConfig:
     @property
     def base_url(self):
         """Generate the base_url for bundle.json."""
-        parts = self.bundle_dir.rstrip("/").split("/")
-        if is_semver(parts[-1]):
-            return (
-                f"https://github.com/hydrolix/integration-deployment-templates"
-                f"/blob/main/{self.source_name}/{self.bundle_name}/{self.version}"
-            )
         return (
             f"https://github.com/hydrolix/integration-deployment-templates"
             f"/blob/main/{self.source_name}/{self.bundle_name}"

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -25,7 +25,6 @@ SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
 
 sys.path.insert(0, SCRIPTS_DIR)
-from configurator.config import is_semver, looks_like_version
 
 
 def main():
@@ -253,32 +252,6 @@ def _merge_config_into_args(args):
         if config_version:
             args.version = config_version
 
-    # Pre-check: config version must match folder name if both are set
-    config_version = data.get("version", "")
-    if config_version:
-        dir_parts = args.bundle_dir.rstrip("/").split("/")
-        folder_name = dir_parts[-1] if dir_parts else ""
-        if is_semver(folder_name) and folder_name != config_version:
-            print(
-                f"Error: bundle-config.json version '{config_version}' does not match "
-                f"folder name '{folder_name}'. They must be identical.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-    # Infer version from directory name if still at default and path is versioned
-    if args.version == "1.0.0":
-        parts = args.bundle_dir.rstrip("/").split("/")
-        if parts and is_semver(parts[-1]):
-            args.version = parts[-1]
-        elif parts and looks_like_version(parts[-1]):
-            print(
-                f"Error: folder name '{parts[-1]}' looks like a version but is not valid "
-                f"semver (expected X.Y.Z, e.g., 1.0.0). Rename the folder to a strict "
-                f"X.Y.Z version or a plain bundle name.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
 
 
 def _apply_track(args):

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 // Pointless comment
 
 use lazy_static::lazy_static;
-use regex::Regex;
 use std::path::PathBuf;
 use tokio::fs;
 use walkdir::WalkDir;
@@ -141,10 +140,7 @@ async fn main() {
 
     let mut bundles_checked = 0;
 
-    // Reject any directories that look like versions but aren't strict X.Y.Z
-    reject_invalid_version_dirs();
-
-    let bundle_list = filter_to_latest_versions(find_bundle_files());
+    let bundle_list = find_bundle_files();
 
     let mut final_bundle_list: Vec<Bundle> = vec![];
     let mut all_bundle_list: Vec<Bundle> = vec![];
@@ -177,26 +173,7 @@ async fn main() {
 
         bundles_checked += 1;
 
-        // Extract version directory name if this is a versioned path
-        let dir_version: Option<String> = {
-            let base_path = std::path::Path::new(&base_dir);
-            let last_component = base_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if is_semver(last_component) {
-                Some(last_component.to_string())
-            } else if looks_like_version(last_component) {
-                eprintln!(
-                    "ERROR: folder name '{}' looks like a version but is not valid \
-                     semver (expected X.Y.Z, e.g., 1.0.0). Rename the folder to a strict \
-                     X.Y.Z version or a plain bundle name.",
-                    last_component
-                );
-                std::process::exit(1);
-            } else {
-                None
-            }
-        };
-
-        match validate_bundle(&base_dir, &bundle, dir_version.as_deref()).await {
+        match validate_bundle(&base_dir, &bundle).await {
             Ok(_) => (),
             Err(e) => {
                 eprintln!("ERROR: Failed bundle validation: {e}");
@@ -227,11 +204,7 @@ async fn main() {
 }
 
 // These are all of our tests...
-async fn validate_bundle(
-    base: &str,
-    bundle: &Bundle,
-    dir_version: Option<&str>,
-) -> Result<(), String> {
+async fn validate_bundle(base: &str, bundle: &Bundle) -> Result<(), String> {
     println!("Base={base} bundle={:?}", bundle);
 
     let mut output: Output = Output::default();
@@ -246,7 +219,7 @@ async fn validate_bundle(
         Err(e) => return Err(format!("Found duplicate tokens: error={e}")),
     }
 
-    match validate::naming_is_valid::run(bundle, dir_version).await {
+    match validate::naming_is_valid::run(bundle).await {
         Ok(_) => (),
         Err(e) => return Err(format!("Found bad naming: error={e}")),
     }
@@ -432,121 +405,17 @@ async fn validate_bundle(
     Ok(())
 }
 
-/// Scan for directories that look like versions but aren't strict X.Y.Z semver.
-/// This catches folders like "1.0.0-beta", "1.0", "2.0.0rc1" before they silently
-/// bypass version detection.
-fn reject_invalid_version_dirs() {
-    let search_path = if *SCAN_WIP { "./WIP" } else { "." };
-
-    for entry in WalkDir::new(search_path)
-        .max_depth(3)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_dir())
-    {
-        let dir_name = entry.file_name().to_str().unwrap_or("");
-        if looks_like_version(dir_name) {
-            eprintln!(
-                "ERROR: folder name '{}' looks like a version but is not valid \
-                 semver (expected X.Y.Z, e.g., 1.0.0). Rename the folder to a strict \
-                 X.Y.Z version or a plain bundle name.\n  Path: {}",
-                dir_name,
-                entry.path().display()
-            );
-            std::process::exit(1);
-        }
-    }
-}
-
-// Update find_bundle_files to handle WIP location
+// Find all bundle.json files in the repo
 fn find_bundle_files() -> Vec<std::path::PathBuf> {
     let search_path = if *SCAN_WIP { "./WIP" } else { "." };
 
     WalkDir::new(search_path)
-        .max_depth(4)
+        .max_depth(3)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_name() == "bundle.json")
         .map(|e| e.path().to_path_buf())
         .collect()
-}
-
-/// Check if a directory name is a semver version string (e.g., "1.0.0").
-fn is_semver(s: &str) -> bool {
-    lazy_static! {
-        static ref SEMVER_RE: Regex = Regex::new(r"^\d+\.\d+\.\d+$").unwrap();
-    }
-    SEMVER_RE.is_match(s)
-}
-
-/// Check if a string looks like a version but isn't strict X.Y.Z semver.
-/// Catches names like "1.0.0-beta", "1.0", "2.0.0rc1".
-fn looks_like_version(s: &str) -> bool {
-    lazy_static! {
-        static ref VERSION_LIKE_RE: Regex = Regex::new(r"^\d+\.").unwrap();
-    }
-    VERSION_LIKE_RE.is_match(s) && !is_semver(s)
-}
-
-/// Parse a semver string into a comparable tuple.
-fn parse_semver(s: &str) -> (u32, u32, u32) {
-    let parts: Vec<u32> = s.split('.').filter_map(|p| p.parse().ok()).collect();
-    (
-        parts.first().copied().unwrap_or(0),
-        parts.get(1).copied().unwrap_or(0),
-        parts.get(2).copied().unwrap_or(0),
-    )
-}
-
-/// Filter bundle paths so that only the latest version per bundle identity is kept.
-/// Non-versioned (flat) paths are always included.
-fn filter_to_latest_versions(paths: Vec<PathBuf>) -> Vec<PathBuf> {
-    use std::collections::HashMap;
-
-    let mut versioned: HashMap<PathBuf, (PathBuf, (u32, u32, u32))> = HashMap::new();
-    let mut flat: Vec<PathBuf> = Vec::new();
-
-    for path in paths {
-        // Parent of bundle.json — could be a version dir or a bundle dir
-        let parent = match path.parent() {
-            Some(p) => p,
-            None => {
-                flat.push(path);
-                continue;
-            }
-        };
-
-        let parent_name = parent.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-        if is_semver(parent_name) {
-            // Versioned path: grandparent is the bundle identity
-            let bundle_identity = match parent.parent() {
-                Some(gp) => gp.to_path_buf(),
-                None => {
-                    flat.push(path);
-                    continue;
-                }
-            };
-            let ver = parse_semver(parent_name);
-
-            match versioned.get(&bundle_identity) {
-                Some((_, existing_ver)) if ver > *existing_ver => {
-                    versioned.insert(bundle_identity, (path, ver));
-                }
-                None => {
-                    versioned.insert(bundle_identity, (path, ver));
-                }
-                _ => {} // existing version is higher or equal, skip
-            }
-        } else {
-            flat.push(path);
-        }
-    }
-
-    let mut result: Vec<PathBuf> = flat;
-    result.extend(versioned.into_values().map(|(path, _)| path));
-    result.sort();
-    result
 }
 
 async fn file_to_bundle(file_path: &str) -> Result<Bundle, String> {

--- a/src/validate/naming_is_valid.rs
+++ b/src/validate/naming_is_valid.rs
@@ -1,6 +1,6 @@
 use crate::models::bundle::Bundle;
 
-pub async fn run(bundle: &Bundle, dir_version: Option<&str>) -> Result<(), String> {
+pub async fn run(bundle: &Bundle) -> Result<(), String> {
     // Check method consistency
     let method = &bundle.method;
     let method_title = &bundle.ui.method.full_title;
@@ -47,19 +47,6 @@ pub async fn run(bundle: &Bundle, dir_version: Option<&str>) -> Result<(), Strin
             file!(),
             line!()
         ));
-    }
-
-    // Check version directory matches bundle metadata version
-    if let Some(dir_ver) = dir_version {
-        if version != dir_ver {
-            return Err(format!(
-                "ERROR: {}.{} Version directory '{}' does not match bundle metadata version '{}'",
-                file!(),
-                line!(),
-                dir_ver,
-                version
-            ));
-        }
     }
 
     // Check maintainer email format

--- a/src/validate/no_global_duplicates.rs
+++ b/src/validate/no_global_duplicates.rs
@@ -3,30 +3,24 @@ use std::collections::HashMap;
 use crate::models::bundle::Bundle;
 
 pub fn run(bundles: &Vec<Bundle>) -> Result<(), String> {
-    // Checking for duplicated bundle names — allow same name only if base_url differs
-    // (which indicates different versions of the same bundle)
+    // Checking for duplicated bundle names
     {
         let mut seen: HashMap<String, String> = HashMap::new(); // name -> base_url
         for b in bundles {
-            if let Some(existing_url) = seen.get(&b.name) {
-                if existing_url == &b.base_url {
-                    return Err(format!(
-                        "ERROR: {}.{} Duplicated-Bundle-Name url={} error={}",
-                        file!(),
-                        line!(),
-                        b.base_url,
-                        b.name,
-                    ));
-                }
-                // Same name but different base_url — different versions, allow it
-            } else {
-                seen.insert(b.name.clone(), b.base_url.clone());
+            if seen.contains_key(&b.name) {
+                return Err(format!(
+                    "ERROR: {}.{} Duplicated-Bundle-Name url={} error={}",
+                    file!(),
+                    line!(),
+                    b.base_url,
+                    b.name,
+                ));
             }
+            seen.insert(b.name.clone(), b.base_url.clone());
         }
     }
 
-    // Checking for duplicated source names in the UI — allow same full_title
-    // only if the bundles share the same name (i.e., same bundle, different versions)
+    // Checking for duplicated source names in the UI
     {
         let mut seen: HashMap<String, String> = HashMap::new(); // full_title -> bundle name
         for b in bundles {
@@ -40,7 +34,6 @@ pub fn run(bundles: &Vec<Bundle>) -> Result<(), String> {
                         b.ui.source.full_title
                     ));
                 }
-                // Same full_title and same bundle name — different versions, allow it
             } else {
                 seen.insert(b.ui.source.full_title.clone(), b.name.clone());
             }


### PR DESCRIPTION
## Summary

- Remove all version-directory assumptions (`source/bundle/X.Y.Z/`) from the Rust validator, Python configurator, CI pipeline, and contributor docs
- Flatten `trafficpeak/security/0.9.0/` to `trafficpeak/security/`
- Version metadata preserved in `bundle-config.json` and `bundle.json` for CAC formatting — only the filesystem structure changes

**Why:** Vortex discovers bundles at a fixed directory depth with no version awareness. The team has decided not to add version support to Vortex. Versioned directories block in-flight bundles from being deployed.

**Rollout:** After this merges, in-flight feature branches pull main, flatten their bundle directories, and re-run the pipeline.

### Changes by layer

| Layer | What changed |
|-------|-------------|
| Rust validator (`src/`) | Removed `filter_to_latest_versions`, `reject_invalid_version_dirs`, semver helpers, `dir_version` extraction. Reduced `max_depth` to 3. Simplified duplicate detection. |
| Python configurator (`scripts/`) | Removed semver path stripping from `_infer_source_name`, `_infer_bundle_name`, `base_url`. Removed version-from-directory inference in `run_pipeline.py`. |
| CI pipeline (`bundle-ci.yml`) | Removed version freeze logic and `[0-9]*.*` subdirectory scanning fallback. |
| Documentation | Updated `HOW-TO-CONTRIBUTE.md` for flat directory layout. |
| Bundle migration | Moved `trafficpeak/security/0.9.0/*` → `trafficpeak/security/`, updated `base_url`. |

**Note:** Vortex will separately need to update its `Bundle` struct and scan logic to support folder/subfolder paths for CAC-formatted bundles (LOTC-1355).

## Test plan

- [x] `cargo run` — all 11 bundles pass validation including flattened `trafficpeak_security`
- [x] `python3 scripts/run_pipeline.py --bundle-dir trafficpeak/security --config trafficpeak/security/bundle-config.json --dry-run --verbose` — pipeline passes, correct source/bundle inference and flat base_url
- [x] Portables output still uses versioned paths (`portables/<bundle>/<version>/`) for CAC compatibility
- [ ] CI pipeline runs successfully on this PR

Jira: https://hydrolix.atlassian.net/browse/LOTC-1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)