### PR TITLE
LOTC-1374: add summary_tables generation support

### DIFF
--- a/scripts/converters/discoverer.py
+++ b/scripts/converters/discoverer.py
@@ -187,7 +187,7 @@ class AssetDiscoverer:
         """Find summary SQL files."""
         summaries = []
 
-        for sql_file in folder.glob('*.sql'):
+        for sql_file in sorted(folder.glob('*.sql')):
             name = sql_file.stem
             summaries.append(Summary(
                 name=name,

--- a/scripts/converters/hydrolix_gen.py
+++ b/scripts/converters/hydrolix_gen.py
@@ -140,15 +140,16 @@ class HydrolixGenerator:
         tables_dir = hydrolix_dir / "tables"
         tables_dir.mkdir(parents=True, exist_ok=True)
         for summary in summaries:
-            shutil.copy2(summary.sql_file_path, tables_dir / f"{summary.name}.sql")
+            sanitized_name = sanitize_cac_name(summary.name)
+            shutil.copy2(summary.sql_file_path, tables_dir / f"{sanitized_name}.sql")
             yaml_content = {
                 '__extend__': '../../../../../../hydrolix/_defaults/table_summary_base_defaults.yaml',
-                'description': summary.name,
-                'settings': {'summary': {'sql': {'__extend__': f'{summary.name}.sql'}}}
+                'description': sanitized_name,
+                'settings': {'summary': {'sql': {'__extend__': f'{sanitized_name}.sql'}}}
             }
-            write_file(tables_dir / f"{summary.name}.yaml", dump_yaml(yaml_content, sort_keys=False))
+            write_file(tables_dir / f"{sanitized_name}.yaml", dump_yaml(yaml_content, sort_keys=False))
             if self.verbose:
-                print(f"  Generated summary table: {summary.name}")
+                print(f"  Generated summary table: {sanitized_name}")
 
     def _generate_resources_file(self, hydrolix_dir: Path, assets: BundleAssets, table_name: str):
         """Generate main resources.hdp.yaml file with nested structure."""
@@ -187,7 +188,7 @@ class HydrolixGenerator:
         # Add summary_tables section
         if assets.summaries:
             resources['summary_tables'] = {
-                summary.name: {'__extend__': f'tables/{summary.name}.yaml'}
+                sanitize_cac_name(summary.name): {'__extend__': f'tables/{sanitize_cac_name(summary.name)}.yaml'}
                 for summary in assets.summaries
             }
 

--- a/scripts/converters/hydrolix_gen.py
+++ b/scripts/converters/hydrolix_gen.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 from typing import List
 
-from utils.models import BundleAssets, Transform, Function, Dictionary
+from utils.models import BundleAssets, Transform, Function, Dictionary, Summary
 from utils.yaml_utils import dump_yaml
 import json
 
@@ -32,6 +32,10 @@ class HydrolixGenerator:
         if assets.transforms:
             self._generate_table(hydrolix_dir, table_name, metadata=metadata)
             self._copy_transforms(hydrolix_dir, assets.transforms)
+
+        # Generate summary tables
+        if assets.summaries:
+            self._generate_summary_tables(hydrolix_dir, assets.summaries)
 
         # Copy function and dictionary definitions
         if assets.functions:
@@ -131,6 +135,21 @@ class HydrolixGenerator:
             if self.verbose:
                 print(f"  Copied dictionary: {d.name}/schema_definition.json")
 
+    def _generate_summary_tables(self, hydrolix_dir: Path, summaries: List[Summary]):
+        """Generate summary table YAML wrappers and copy SQL files."""
+        tables_dir = hydrolix_dir / "tables"
+        tables_dir.mkdir(parents=True, exist_ok=True)
+        for summary in summaries:
+            shutil.copy2(summary.sql_file_path, tables_dir / f"{summary.name}.sql")
+            yaml_content = {
+                '__extend__': '../../../../../../hydrolix/_defaults/table_summary_base_defaults.yaml',
+                'description': summary.name,
+                'settings': {'summary': {'sql': {'__extend__': f'{summary.name}.sql'}}}
+            }
+            write_file(tables_dir / f"{summary.name}.yaml", dump_yaml(yaml_content, sort_keys=False))
+            if self.verbose:
+                print(f"  Generated summary table: {summary.name}")
+
     def _generate_resources_file(self, hydrolix_dir: Path, assets: BundleAssets, table_name: str):
         """Generate main resources.hdp.yaml file with nested structure."""
         resources = {}
@@ -163,6 +182,13 @@ class HydrolixGenerator:
 
             resources['transforms'] = {
                 table_name: transforms_dict
+            }
+
+        # Add summary_tables section
+        if assets.summaries:
+            resources['summary_tables'] = {
+                summary.name: {'__extend__': f'tables/{summary.name}.yaml'}
+                for summary in assets.summaries
             }
 
         # Add functions section


### PR DESCRIPTION
## Summary

- Adds `_generate_summary_tables()` to `HydrolixGenerator` — when a bundle has a `summaries/` directory, copies each `.sql` file to `hydrolix/tables/<name>.sql` and generates a `.yaml` wrapper extending `table_summary_base_defaults.yaml`
- Adds `summary_tables` block to `resources.hdp.yaml` referencing each generated YAML
- Applies `sanitize_cac_name()` to summary names (consistent with how transforms are handled)
- Sorts discovered summary SQL files for deterministic output order

## Changes

- `scripts/converters/hydrolix_gen.py` — new `_generate_summary_tables()` method; `summary_tables` block in `_generate_resources_file()`
- `scripts/converters/discoverer.py` — `sorted()` added to `_discover_summaries` glob

## Test plan

- [x] Run `bundle_to_yaml.py` against a bundle with a `summaries/` directory and verify `hydrolix/tables/<name>.sql`, `hydrolix/tables/<name>.yaml`, and `summary_tables` block appear in `resources.hdp.yaml`
- [x] Run against a bundle without `summaries/` and verify no `summary_tables` block is emitted
- [x] Verify output passes Rust bundle validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)