### PR TITLE
LOTC-1377: sample data timestamp freshness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,5 @@ sha2 = "0.10.9"
 walkdir = "2.5.0"
 regex = "1.11.2"
 
-
+[dev-dependencies]
+tempfile = "3"

--- a/HOW-TO-CONTRIBUTE.md
+++ b/HOW-TO-CONTRIBUTE.md
@@ -149,6 +149,7 @@ Dashboards are automatically placed in the correct Grafana folder based on `data
 **Transformations**
 - Transformation configuration JSON files
 - **Must include sample data** (`sample_data.json`) for each transformation
+- **Timestamp freshness**: Sample data timestamps should be within the last 6 months. On the full pipeline track (Track 1), stale timestamps are automatically shifted to the 1st of the current month. On the validation-only track (Track 2), stale timestamps produce a warning.
 - Organize by ingestion method or data source (e.g., `transformations/cloudflare/`, `transformations/firehose/`)
 - Place in `transformations/` folder
 

--- a/WHAT-IS-CHECKED.md
+++ b/WHAT-IS-CHECKED.md
@@ -29,7 +29,7 @@ The bundle checker performs validation in two phases:
 **Checks**:
 - **File Accessibility**: All transform files can be read from disk
 - **JSON Validity**: Transform files contain valid JSON syntax
-- **Required Fields**: 
+- **Required Fields**:
   - `name` field exists and is a non-empty string
   - `subtype` field (if present) must equal "firehose"
 - **Data Integrity**: Transform file structure matches expected schema
@@ -57,7 +57,26 @@ The bundle checker performs validation in two phases:
 - Empty sample data object or string
 - Sample data field exists but contains only whitespace
 
-### 4. Duplicate Token Validation (`no_duplicate_tokens.rs`)
+### 4. Sample Data Freshness (`sample_data_freshness.rs`)
+
+**Purpose**: Warns when sample data contains stale timestamps that may cause Grafana dashboard panels to appear empty due to default time range filters.
+
+**Checks**:
+- **Primary Timestamp Detection**: Identifies the primary epoch column from the transform's `output_columns` schema (where `datatype.type == "epoch"` and `datatype.primary == true`)
+- **Staleness Check**: Compares the primary timestamp value in `sample_data` against the current time
+- **Threshold**: Timestamps older than 6 months (183 days) are flagged as stale
+
+**Behavior**:
+- **Warning only** — does not fail validation. Stale timestamps are logged as warnings but do not block merges.
+- On the full pipeline track (Track 1), the Python configurator automatically shifts stale timestamps to the 1st of the current month before this validator runs.
+- On the validation-only track (Track 2), this check serves as a safety net to surface staleness.
+
+**Skipped when**:
+- No primary epoch column exists in the transform schema
+- The primary timestamp value is not numeric in sample_data
+- The `output_columns` field is missing from the transform
+
+### 5. Duplicate Token Validation (`no_duplicate_tokens.rs`)
 
 **Purpose**: Prevents naming conflicts within a single bundle.
 
@@ -76,7 +95,7 @@ The bundle checker performs validation in two phases:
 - Table name contains invalid characters (not alphanumeric or underscore)
 - Duplicate dashboard variable values
 
-### 5. Checksum Validation (`no_bad_checksums.rs`)
+### 6. Checksum Validation (`no_bad_checksums.rs`)
 
 **Purpose**: Ensures file integrity through SHA256 checksum verification.
 
@@ -91,7 +110,7 @@ The bundle checker performs validation in two phases:
 - Computed SHA256 doesn't match declared checksum
 - Missing checksum when expected
 
-### 6. Naming Convention Validation (`naming_is_valid.rs`)
+### 7. Naming Convention Validation (`naming_is_valid.rs`)
 
 **Purpose**: Enforces consistent naming conventions across bundle components.
 
@@ -116,7 +135,7 @@ The bundle checker performs validation in two phases:
 - Invalid email format for maintainer
 - Empty description
 
-### 7. Dashboard Validation (`dashboard_is_valid.rs`)
+### 8. Dashboard Validation (`dashboard_is_valid.rs`)
 
 **Purpose**: Validates Grafana dashboard files and their template variables.
 
@@ -128,7 +147,7 @@ The bundle checker performs validation in two phases:
   - `__DATASOURCE__` - Data source placeholder
   - `__PROJECT_NAME__` - Project name placeholder
   - All table dashboard variables from bundle configuration
-- **Dashboard Structure**: 
+- **Dashboard Structure**:
   - Top-level `dashboard` object exists
   - No hardcoded `id` field (must use placeholder)
 
@@ -141,7 +160,7 @@ The bundle checker performs validation in two phases:
 
 ## Global Cross-Bundle Validation
 
-### 8. Global Duplicate Prevention (`no_global_duplicates.rs`)
+### 9. Global Duplicate Prevention (`no_global_duplicates.rs`)
 
 **Purpose**: Prevents conflicts across all bundles in the repository.
 

--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -1,12 +1,18 @@
 """Phase 2a-2d: Transform organization, cleanup, and sample data extraction."""
 
+import calendar
 import json
 import os
 import shutil
 import sys
+import time
+from datetime import datetime, timezone
 
 from utils.file_utils import read_json, write_json
 from .constants import TRANSFORM_METADATA_FIELDS
+
+# 183 days in seconds (approximately 6 months)
+_STALENESS_THRESHOLD_SECS = 183 * 86400
 
 
 def run_transform_organization(config, state):
@@ -229,8 +235,9 @@ def _extract_sample_data(data, tinfo, config, state):
     # Update transform's sample_data to normalized single object
     settings["sample_data"] = normalized
 
-    # Write sample_data.json
+    # Write sample_data.json (shift stale timestamps only on real runs)
     if not config.dry_run:
+        _shift_stale_timestamps(normalized, data, tinfo, config)
         write_json(tinfo.sample_data_path, normalized)
         state.files_created.append(tinfo.sample_data_path)
 
@@ -244,3 +251,81 @@ def _extract_sample_data(data, tinfo, config, state):
         )
 
     return True
+
+
+_FORMAT_DIVISORS = {"s": 1, "ms": 1_000, "us": 1_000_000, "ns": 1_000_000_000}
+
+
+def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
+    """Shift stale epoch timestamps in sample_data to the 1st of the current month.
+
+    Uses the transform's output_columns schema to identify epoch-typed fields.
+    Only shifts if the primary timestamp is older than 6 months.
+    Handles epoch formats: s, ms, us, ns.
+    """
+    output_columns = transform_data.get("settings", {}).get("output_columns", [])
+    if not output_columns:
+        return
+
+    # Find the primary epoch column and its format
+    primary_col_name = None
+    primary_format = "s"
+    epoch_col_names = []
+    for col in output_columns:
+        dt = col.get("datatype", {})
+        if dt.get("type") == "epoch":
+            epoch_col_names.append(col["name"])
+            if dt.get("primary"):
+                primary_col_name = col["name"]
+                primary_format = dt.get("format", "s")
+
+    if not primary_col_name:
+        if config.verbose:
+            print(
+                f"[Transform Org] No primary epoch column found in "
+                f"{os.path.basename(tinfo.final_path)}, skipping timestamp shift",
+                file=sys.stderr,
+            )
+        return
+
+    primary_value = sample_data.get(primary_col_name)
+    if not isinstance(primary_value, (int, float)):
+        if config.verbose:
+            print(
+                f"[Transform Org] Primary timestamp '{primary_col_name}' is not numeric "
+                f"in sample_data for {os.path.basename(tinfo.final_path)}, skipping shift",
+                file=sys.stderr,
+            )
+        return
+
+    # Convert to seconds for comparison regardless of format
+    divisor = _FORMAT_DIVISORS.get(primary_format, 1)
+    primary_secs = int(primary_value) // divisor
+
+    now_epoch = int(time.time())
+    staleness = now_epoch - primary_secs
+
+    if staleness <= _STALENESS_THRESHOLD_SECS:
+        return
+
+    # Target: 1st of current month, midnight UTC
+    now_utc = datetime.now(timezone.utc)
+    first_of_month = now_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    target_epoch = int(calendar.timegm(first_of_month.timetuple()))
+
+    # Delta in the native format units
+    delta = (target_epoch - primary_secs) * divisor
+
+    shifted_fields = []
+    for col_name in epoch_col_names:
+        if col_name in sample_data and isinstance(sample_data[col_name], (int, float)):
+            sample_data[col_name] = int(sample_data[col_name]) + delta
+            shifted_fields.append(col_name)
+
+    if config.verbose and shifted_fields:
+        print(
+            f"[Transform Org] Shifted stale timestamps in "
+            f"{os.path.basename(tinfo.sample_data_path)}: "
+            f"{', '.join(shifted_fields)} (delta={delta // divisor}s, format={primary_format})",
+            file=sys.stderr,
+        )

--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -267,17 +267,18 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
     if not output_columns:
         return
 
-    # Find the primary epoch column and its format
+    # Find the primary epoch column and build a map of epoch column formats
     primary_col_name = None
     primary_format = "s"
-    epoch_col_names = []
+    epoch_col_formats = {}  # col_name -> format string
     for col in output_columns:
         dt = col.get("datatype", {})
         if dt.get("type") == "epoch":
-            epoch_col_names.append(col["name"])
+            col_format = dt.get("format", "s")
+            epoch_col_formats[col["name"]] = col_format
             if dt.get("primary"):
                 primary_col_name = col["name"]
-                primary_format = dt.get("format", "s")
+                primary_format = col_format
 
     if not primary_col_name:
         if config.verbose:
@@ -313,19 +314,21 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
     first_of_month = now_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     target_epoch = int(calendar.timegm(first_of_month.timetuple()))
 
-    # Delta in the native format units
-    delta = (target_epoch - primary_secs) * divisor
+    # Delta in seconds (applied per-column in each column's native units)
+    delta_secs = target_epoch - primary_secs
 
     shifted_fields = []
-    for col_name in epoch_col_names:
+    for col_name, col_format in epoch_col_formats.items():
         if col_name in sample_data and isinstance(sample_data[col_name], (int, float)):
-            sample_data[col_name] = int(sample_data[col_name]) + delta
+            col_divisor = _FORMAT_DIVISORS.get(col_format, 1)
+            col_delta = delta_secs * col_divisor
+            sample_data[col_name] = int(sample_data[col_name]) + col_delta
             shifted_fields.append(col_name)
 
     if config.verbose and shifted_fields:
         print(
             f"[Transform Org] Shifted stale timestamps in "
             f"{os.path.basename(tinfo.sample_data_path)}: "
-            f"{', '.join(shifted_fields)} (delta={delta // divisor}s, format={primary_format})",
+            f"{', '.join(shifted_fields)} (delta={delta_secs}s)",
             file=sys.stderr,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,11 @@ async fn validate_bundle(base: &str, bundle: &Bundle) -> Result<(), String> {
         Err(e) => return Err(format!("No sample data: error={e}")),
     }
 
+    // Check sample data timestamp freshness (warning only, doesn't fail validation)
+    for w in validate::sample_data_freshness::run(base, bundle).await {
+        eprintln!("WARNING: {w}");
+    }
+
     match validate::summary_table::run(bundle) {
         Ok(_) => (),
         Err(e) => return Err(format!("Bad summary table: error={e}")),

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -7,6 +7,7 @@ pub mod no_bad_checksums;
 pub mod no_duplicate_tokens;
 pub mod no_global_duplicates;
 pub mod sample_data_exists;
+pub mod sample_data_freshness;
 pub mod summary_column_schema;
 pub mod summary_table;
 pub mod summary_table_references;

--- a/src/validate/sample_data_freshness.rs
+++ b/src/validate/sample_data_freshness.rs
@@ -1,0 +1,257 @@
+use crate::models::bundle::Bundle;
+use serde_json::Value;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::fs;
+
+/// Approximately 6 months in seconds (183 days).
+const STALENESS_THRESHOLD_SECS: u64 = 183 * 86400;
+
+/// Returns a list of warning messages for stale sample_data timestamps.
+/// An empty list means all timestamps are fresh.
+pub async fn run(base: &str, bundle: &Bundle) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    for t in &bundle.tables {
+        for tt in &t.transforms {
+            let full_path = format!("{base}/{}", tt.path);
+
+            let content = match fs::read_to_string(&full_path).await {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let transform_json: Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let output_columns = match transform_json["settings"]["output_columns"].as_array() {
+                Some(cols) => cols,
+                None => continue,
+            };
+
+            // Find the primary epoch column name and format
+            let primary_info = output_columns.iter().find_map(|col| {
+                let dt = col.get("datatype")?;
+                if dt.get("type")?.as_str()? == "epoch" && dt.get("primary")?.as_bool()? {
+                    let name = col.get("name")?.as_str()?.to_string();
+                    let format = dt
+                        .get("format")
+                        .and_then(|f| f.as_str())
+                        .unwrap_or("s")
+                        .to_string();
+                    Some((name, format))
+                } else {
+                    None
+                }
+            });
+
+            let (primary_col_name, primary_format) = match primary_info {
+                Some(info) => info,
+                None => continue,
+            };
+
+            let sample_data = &transform_json["settings"]["sample_data"];
+
+            let primary_value = match sample_data.get(&primary_col_name) {
+                Some(Value::Number(n)) => match n.as_u64() {
+                    Some(v) => v,
+                    None => match n.as_f64() {
+                        Some(v) => v as u64,
+                        None => continue,
+                    },
+                },
+                _ => continue,
+            };
+
+            // Convert to seconds based on format
+            let divisor: u64 = match primary_format.as_str() {
+                "ms" => 1_000,
+                "us" => 1_000_000,
+                "ns" => 1_000_000_000,
+                _ => 1, // "s" or unknown defaults to seconds
+            };
+            let primary_secs = primary_value / divisor;
+
+            if now_epoch > primary_secs && (now_epoch - primary_secs) > STALENESS_THRESHOLD_SECS {
+                let age_days = (now_epoch - primary_secs) / 86400;
+                warnings.push(format!(
+                    "Stale sample_data in {}: primary timestamp '{}' is ~{} days old (threshold: {} days)",
+                    tt.path, primary_col_name, age_days, STALENESS_THRESHOLD_SECS / 86400
+                ));
+            }
+        }
+    }
+
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::fs;
+
+    fn now_epoch() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn make_transform_json(primary_ts: u64) -> String {
+        format!(
+            r#"{{
+                "name": "test_transform",
+                "settings": {{
+                    "output_columns": [
+                        {{
+                            "name": "timestamp",
+                            "datatype": {{
+                                "type": "epoch",
+                                "primary": true,
+                                "format": "s",
+                                "resolution": "ms"
+                            }}
+                        }},
+                        {{
+                            "name": "bytes",
+                            "datatype": {{
+                                "type": "uint64"
+                            }}
+                        }}
+                    ],
+                    "sample_data": {{
+                        "timestamp": {},
+                        "bytes": 1234
+                    }}
+                }}
+            }}"#,
+            primary_ts
+        )
+    }
+
+    fn make_bundle(transform_path: &str) -> Bundle {
+        serde_json::from_str(&format!(
+            r#"{{
+                "name": "test-bundle",
+                "source": "test",
+                "method": "http_streaming",
+                "beta": false,
+                "base_url": "https://example.com/test",
+                "dashboard": {{
+                    "path": "dashboards/test.json",
+                    "project_var": "__PROJECT_NAME__"
+                }},
+                "tables": [{{
+                    "dashboard_var": "__TABLE_NAME__",
+                    "name": "logs",
+                    "transforms": [{{
+                        "path": "{}"
+                    }}]
+                }}],
+                "ui": {{
+                    "primary_url": "https://example.com",
+                    "method": {{ "full_title": "HTTP Streaming", "icon_url": "https://example.com/icon.png" }},
+                    "source": {{ "full_title": "Test Source", "icon_url": "https://example.com/icon.png" }},
+                    "data_category": "cdn"
+                }},
+                "metadata": {{
+                    "version": "1.0.0",
+                    "maintainer": "test",
+                    "description": "test bundle",
+                    "channel_type": "AWS"
+                }}
+            }}"#,
+            transform_path
+        ))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_fresh_data_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let transform_path = "transformations/transform.json";
+        let full_path = dir.path().join(transform_path);
+        fs::create_dir_all(full_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        // Timestamp from 1 day ago — fresh
+        let ts = now_epoch() - 86400;
+        fs::write(&full_path, make_transform_json(ts))
+            .await
+            .unwrap();
+
+        let bundle = make_bundle(transform_path);
+        let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
+        assert!(
+            warnings.is_empty(),
+            "Fresh data should produce no warnings: {:?}",
+            warnings
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stale_data_warns() {
+        let dir = tempfile::tempdir().unwrap();
+        let transform_path = "transformations/transform.json";
+        let full_path = dir.path().join(transform_path);
+        fs::create_dir_all(full_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        // Timestamp from 1 year ago — stale
+        let ts = now_epoch() - (365 * 86400);
+        fs::write(&full_path, make_transform_json(ts))
+            .await
+            .unwrap();
+
+        let bundle = make_bundle(transform_path);
+        let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
+        assert!(!warnings.is_empty(), "Stale data should produce warnings");
+        assert!(
+            warnings[0].contains("Stale sample_data"),
+            "Warning should mention staleness: {}",
+            warnings[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_primary_column_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let transform_path = "transformations/transform.json";
+        let full_path = dir.path().join(transform_path);
+        fs::create_dir_all(full_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        // Transform with no primary epoch column
+        let json = r#"{
+            "name": "test",
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "bytes",
+                        "datatype": { "type": "uint64" }
+                    }
+                ],
+                "sample_data": { "bytes": 1234 }
+            }
+        }"#;
+        fs::write(&full_path, json).await.unwrap();
+
+        let bundle = make_bundle(transform_path);
+        let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
+        assert!(
+            warnings.is_empty(),
+            "No primary column should produce no warnings: {:?}",
+            warnings
+        );
+    }
+}

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -1,0 +1,368 @@
+"""Tests for timestamp freshness shifting in Phase 2d (transform_organizer)."""
+
+import json
+import os
+import sys
+import time
+import types
+from datetime import datetime, timezone
+from unittest.mock import patch
+import calendar
+
+import pytest
+
+# Stub out utils.file_utils before importing configurator modules
+_utils_pkg = types.ModuleType("utils")
+_utils_pkg.file_utils = types.ModuleType("utils.file_utils")
+
+
+def _stub_read_json(path, *a, **kw):
+    with open(path) as f:
+        return json.load(f)
+
+
+_utils_pkg.file_utils.read_json = _stub_read_json
+_utils_pkg.file_utils.write_json = lambda *a, **kw: None
+sys.modules.setdefault("utils", _utils_pkg)
+sys.modules.setdefault("utils.file_utils", _utils_pkg.file_utils)
+
+from scripts.configurator.transform_organizer import (
+    _shift_stale_timestamps,
+    _extract_sample_data,
+    _STALENESS_THRESHOLD_SECS,
+)
+from scripts.configurator.config import BundleConfig, BundleState, TransformInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_epoch():
+    return int(time.time())
+
+
+def _first_of_month_epoch():
+    now_utc = datetime.now(timezone.utc)
+    first = now_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return int(calendar.timegm(first.timetuple()))
+
+
+def _make_transform_data(primary_ts, extra_epoch_ts=None, extra_non_epoch=None):
+    """Build a transform dict with output_columns and sample_data."""
+    columns = [
+        {
+            "name": "timestamp",
+            "datatype": {
+                "type": "epoch",
+                "primary": True,
+                "format": "s",
+                "resolution": "ms",
+            },
+        },
+        {
+            "name": "bytes",
+            "datatype": {"type": "uint64"},
+        },
+    ]
+    sample = {"timestamp": primary_ts, "bytes": 4096}
+
+    if extra_epoch_ts is not None:
+        columns.append(
+            {
+                "name": "ts_sec_idx",
+                "datatype": {"type": "epoch", "format": "s"},
+            }
+        )
+        sample["ts_sec_idx"] = extra_epoch_ts
+
+    if extra_non_epoch is not None:
+        sample["status_code"] = extra_non_epoch
+
+    return {
+        "name": "test_transform",
+        "settings": {
+            "output_columns": columns,
+            "sample_data": sample,
+        },
+    }
+
+
+def _make_config(tmp_path, verbose=False, dry_run=False):
+    bundle_dir = tmp_path / "aws" / "test_bundle"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    return BundleConfig(
+        bundle_dir=str(bundle_dir),
+        table_name="logs",
+        data_category="cdn",
+        verbose=verbose,
+        dry_run=dry_run,
+    )
+
+
+def _make_tinfo(tmp_path):
+    bundle_dir = tmp_path / "aws" / "test_bundle"
+    transformations_dir = bundle_dir / "transformations"
+    transformations_dir.mkdir(parents=True, exist_ok=True)
+    return TransformInfo(
+        original_path=str(transformations_dir / "transform.json"),
+        final_path=str(transformations_dir / "transform.json"),
+        final_dir=str(transformations_dir),
+        sample_data_path=str(transformations_dir / "sample_data.json"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _shift_stale_timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestShiftStaleTimestamps:
+    """Unit tests for the _shift_stale_timestamps helper."""
+
+    def test_fresh_data_not_modified(self, tmp_path):
+        """Timestamps within 6 months should not be shifted."""
+        fresh_ts = _now_epoch() - (30 * 86400)  # 30 days ago
+        data = _make_transform_data(fresh_ts)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == fresh_ts
+        assert sample["bytes"] == 4096
+
+    def test_stale_data_shifted_to_first_of_month(self, tmp_path):
+        """Timestamps older than 6 months should shift to 1st of current month."""
+        stale_ts = _now_epoch() - (365 * 86400)  # 1 year ago
+        data = _make_transform_data(stale_ts)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        expected_target = _first_of_month_epoch()
+        assert sample["timestamp"] == expected_target
+
+    def test_delta_applied_to_all_epoch_columns(self, tmp_path):
+        """All epoch-typed columns should be shifted by the same delta."""
+        stale_ts = _now_epoch() - (365 * 86400)
+        extra_ts = stale_ts - 3600  # 1 hour before primary
+        data = _make_transform_data(stale_ts, extra_epoch_ts=extra_ts)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        target = _first_of_month_epoch()
+        delta = target - stale_ts
+        assert sample["timestamp"] == target
+        assert sample["ts_sec_idx"] == extra_ts + delta
+
+    def test_non_epoch_columns_untouched(self, tmp_path):
+        """Non-epoch columns should not be modified."""
+        stale_ts = _now_epoch() - (365 * 86400)
+        data = _make_transform_data(stale_ts, extra_non_epoch=200)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["bytes"] == 4096
+        assert sample["status_code"] == 200
+
+    def test_no_primary_column_skips(self, tmp_path):
+        """If no primary epoch column exists, skip without error."""
+        data = {
+            "settings": {
+                "output_columns": [
+                    {"name": "bytes", "datatype": {"type": "uint64"}},
+                ],
+                "sample_data": {"bytes": 4096},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path, verbose=True)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["bytes"] == 4096
+
+    def test_no_output_columns_skips(self, tmp_path):
+        """If output_columns is missing entirely, skip without error."""
+        data = {"settings": {"sample_data": {"timestamp": 1000000000}}}
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == 1000000000
+
+    def test_primary_value_not_numeric_skips(self, tmp_path):
+        """If primary timestamp value is a string, skip without error."""
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {"type": "epoch", "primary": True},
+                    }
+                ],
+                "sample_data": {"timestamp": "not-a-number"},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path, verbose=True)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == "not-a-number"
+
+    def test_threshold_boundary_not_shifted(self, tmp_path):
+        """Data exactly at the 183-day threshold should not be shifted."""
+        fixed_now = 1800000000  # fixed reference time
+        boundary_ts = fixed_now - _STALENESS_THRESHOLD_SECS
+        data = _make_transform_data(boundary_ts)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        with patch("scripts.configurator.transform_organizer.time") as mock_time:
+            mock_time.time.return_value = fixed_now
+            _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == boundary_ts
+
+    def test_threshold_boundary_plus_one_shifted(self, tmp_path):
+        """Data 1 second past the threshold should be shifted."""
+        fixed_now = 1800000000
+        stale_ts = fixed_now - _STALENESS_THRESHOLD_SECS - 1
+        data = _make_transform_data(stale_ts)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        with patch("scripts.configurator.transform_organizer.time") as mock_time:
+            mock_time.time.return_value = fixed_now
+            _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == _first_of_month_epoch()
+
+    def test_millisecond_format_shifted_correctly(self, tmp_path):
+        """Epoch-ms timestamps should be normalized to seconds for comparison and shifted in ms."""
+        stale_secs = _now_epoch() - (365 * 86400)  # 1 year ago in seconds
+        stale_ms = stale_secs * 1000  # convert to milliseconds
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "epoch",
+                            "primary": True,
+                            "format": "ms",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": stale_ms},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        # Should be shifted to first-of-month in milliseconds
+        expected_ms = _first_of_month_epoch() * 1000
+        assert sample["timestamp"] == expected_ms
+
+    def test_millisecond_format_fresh_not_shifted(self, tmp_path):
+        """Fresh ms timestamps should not be shifted."""
+        fresh_secs = _now_epoch() - (30 * 86400)  # 30 days ago
+        fresh_ms = fresh_secs * 1000
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "epoch",
+                            "primary": True,
+                            "format": "ms",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": fresh_ms},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == fresh_ms
+
+
+# ---------------------------------------------------------------------------
+# Integration test: _extract_sample_data with stale timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSampleDataIntegration:
+    """Integration test: Phase 2d extraction + timestamp shifting."""
+
+    def test_extract_shifts_stale_and_writes(self, tmp_path):
+        """Full Phase 2d: extract sample_data from transform with stale ts, verify in-memory data."""
+        config = _make_config(tmp_path)
+        state = BundleState()
+        tinfo = _make_tinfo(tmp_path)
+
+        stale_ts = _now_epoch() - (365 * 86400)
+        transform_data = _make_transform_data(stale_ts)
+
+        # Write transform to disk so _extract_sample_data can read paths
+        transform_path = tinfo.final_path
+        os.makedirs(os.path.dirname(transform_path), exist_ok=True)
+        with open(transform_path, "w") as f:
+            json.dump(transform_data, f)
+
+        ok = _extract_sample_data(transform_data, tinfo, config, state)
+
+        assert ok is True
+        assert state.errors == []
+        assert tinfo.has_sample_data is True
+
+        # Check the in-memory sample_data (modified in-place before writing)
+        sample = transform_data["settings"]["sample_data"]
+        expected_target = _first_of_month_epoch()
+        assert sample["timestamp"] == expected_target
+        assert sample["bytes"] == 4096
+
+    def test_extract_fresh_data_unchanged(self, tmp_path):
+        """Fresh data should pass through extraction without modification."""
+        config = _make_config(tmp_path)
+        state = BundleState()
+        tinfo = _make_tinfo(tmp_path)
+
+        fresh_ts = _now_epoch() - (30 * 86400)
+        transform_data = _make_transform_data(fresh_ts)
+
+        transform_path = tinfo.final_path
+        os.makedirs(os.path.dirname(transform_path), exist_ok=True)
+        with open(transform_path, "w") as f:
+            json.dump(transform_data, f)
+
+        ok = _extract_sample_data(transform_data, tinfo, config, state)
+
+        assert ok is True
+        sample = transform_data["settings"]["sample_data"]
+        assert sample["timestamp"] == fresh_ts

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -162,6 +162,45 @@ class TestShiftStaleTimestamps:
         assert sample["timestamp"] == target
         assert sample["ts_sec_idx"] == extra_ts + delta
 
+    def test_mixed_format_secondary_columns(self, tmp_path):
+        """Secondary epoch columns with different formats get their own per-format delta."""
+        stale_secs = _now_epoch() - (365 * 86400)
+        secondary_ms = (stale_secs - 3600) * 1000  # 1 hour before primary, in ms
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {"type": "epoch", "primary": True, "format": "s"},
+                    },
+                    {
+                        "name": "event_time_ms",
+                        "datatype": {"type": "epoch", "format": "ms"},
+                    },
+                    {"name": "bytes", "datatype": {"type": "uint64"}},
+                ],
+                "sample_data": {
+                    "timestamp": stale_secs,
+                    "event_time_ms": secondary_ms,
+                    "bytes": 4096,
+                },
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        target = _first_of_month_epoch()
+        delta_secs = target - stale_secs
+        # Primary (seconds format) shifted by delta in seconds
+        assert sample["timestamp"] == target
+        # Secondary (ms format) shifted by delta in milliseconds
+        assert sample["event_time_ms"] == secondary_ms + (delta_secs * 1000)
+        # Non-epoch untouched
+        assert sample["bytes"] == 4096
+
     def test_non_epoch_columns_untouched(self, tmp_path):
         """Non-epoch columns should not be modified."""
         stale_ts = _now_epoch() - (365 * 86400)


### PR DESCRIPTION
## Changes

Grafana dashboards break when bundle `sample_data.json` timestamps are older than ~6 months — the default time range excludes them, causing empty panels on the testing cluster.

**Python configurator** (`scripts/configurator/transform_organizer.py`)
- Schema-guided shifting of stale epoch timestamps to 1st of current month (midnight UTC)
- Supports `s`/`ms`/`us`/`ns` formats with per-column divisor lookup
- Inline in Phase 2d (`_extract_sample_data`), only runs on non-dry-run executions

**Rust validator** (`src/validate/sample_data_freshness.rs`)
- New warning-only staleness check (non-blocking, `Vec<String>` return type)
- Safety net for validate-only track bundles that skip the configurator
- Registered in `mod.rs`, called in `main.rs` after `sample_data_exists`

**Tests** (`tests/test_timestamp_freshness.py`, inline Rust tests)
- 14 Python tests: shifting, boundary, edge cases, ms format, mixed-format secondary columns, integration
- 3 Rust tests: fresh/stale/no-primary-column scenarios

**Documentation** (`HOW-TO-CONTRIBUTE.md`, `WHAT-IS-CHECKED.md`)
- Freshness requirement noted in contributor guide
- New validation rule documented with skip conditions

## Test plan
- [x] `python3 -m pytest tests/ -v` — 56 passed
- [x] `cargo test` — 28 passed
- [x] Manual: `python3 scripts/configure_bundle.py --verbose <stale_bundle>` shows shifted timestamps
- [x] Manual: `cargo run -- <bundle>` prints WARNING for stale data, passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)