### PR TITLE
LOTC-1376: auto-detect and sync missing cluster dependencies

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -198,11 +198,6 @@ def resolve_stages(args):
         print("Error: only one --only-* flag allowed", file=sys.stderr)
         sys.exit(2)
 
-    # Dry-run: only stage 2 runs
-    if args.dry_run:
-        _require_stage2_args(args)
-        return [("configure", build_configure_cmd)]
-
     # --only-* mode
     if args.only_portable:
         return [("portable", build_portable_cmd)]
@@ -213,6 +208,11 @@ def resolve_stages(args):
         return [("sync", build_sync_cmd)]
     if args.only_validate:
         return [("validate", build_validate_cmd)]
+
+    # Dry-run (no --only-* flag): only stage 2 runs
+    if args.dry_run:
+        _require_stage2_args(args)
+        return [("configure", build_configure_cmd)]
 
     # Default: all stages, minus any --skip-*
     stages = []

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Pipeline orchestrator for Hydrolix integration deployment bundles.
 
-Chains three stages in order:
-1. bundle_to_yaml.py  — generate portable CaC YAML manifests (before in-place edits)
-2. configure_bundle.py — configure raw bundle assets in-place
-3. Rust validator      — validate the configured bundle
+Chains up to four stages in order:
+1. bundle_to_yaml.py    — generate portable CaC YAML manifests (before in-place edits)
+2. configure_bundle.py  — configure raw bundle assets in-place
+3. sync_cluster_deps.py — sync missing functions/dictionaries to cluster (when env vars set)
+4. Rust validator        — validate the configured bundle
 
 Usage:
     python scripts/run_pipeline.py \
@@ -55,6 +56,9 @@ def main():
         elif name == "configure":
             cmd = build_configure_cmd(args)
             msg = "Configuring bundle..."
+        elif name == "sync":
+            cmd = build_sync_cmd(args)
+            msg = "Syncing cluster dependencies..."
         elif name == "validate":
             # Stage 2 report provides bundle_name for the validator filter
             stage2_report = _find_stage2_report(results)
@@ -66,20 +70,28 @@ def main():
         if not args.json:
             print(f"\n{label} {msg}")
 
-        parse_json = name == "configure"
+        parse_json = name in ("configure", "sync")
         result = run_stage(name, cmd, REPO_ROOT, args.verbose, parse_json=parse_json)
         results.append(result)
 
         if result["status"] == "error":
-            if not args.json:
-                print(f"  ✗ FAILED")
-                if result.get("stderr"):
-                    for line in result["stderr"].strip().splitlines()[-10:]:
-                        print(f"    {line}")
-            print_summary(results, args)
-            sys.exit(1)
+            if name == "sync":
+                # Sync is non-blocking — warn but continue to validation
+                if not args.json:
+                    print(f"  ⚠ Sync warnings (non-blocking)")
+                    if result.get("stderr"):
+                        for line in result["stderr"].strip().splitlines()[-5:]:
+                            print(f"    {line}")
+            else:
+                if not args.json:
+                    print(f"  ✗ FAILED")
+                    if result.get("stderr"):
+                        for line in result["stderr"].strip().splitlines()[-10:]:
+                            print(f"    {line}")
+                print_summary(results, args)
+                sys.exit(1)
 
-        if not args.json:
+        if not args.json and result["status"] != "error":
             _print_stage_success(name, result)
 
     print_summary(results, args)
@@ -126,12 +138,14 @@ Examples:
     skip = parser.add_argument_group("stage selection (skip)")
     skip.add_argument("--skip-portable", action="store_true", help="Skip stage 1")
     skip.add_argument("--skip-configure", action="store_true", help="Skip stage 2")
-    skip.add_argument("--skip-validate", action="store_true", help="Skip stage 3")
+    skip.add_argument("--skip-sync", action="store_true", help="Skip stage 3 (cluster dep sync)")
+    skip.add_argument("--skip-validate", action="store_true", help="Skip stage 4")
 
     only = parser.add_argument_group("stage selection (only)")
     only.add_argument("--only-portable", action="store_true", help="Run only stage 1")
     only.add_argument("--only-configure", action="store_true", help="Run only stage 2")
-    only.add_argument("--only-validate", action="store_true", help="Run only stage 3")
+    only.add_argument("--only-sync", action="store_true", help="Run only stage 3 (cluster dep sync)")
+    only.add_argument("--only-validate", action="store_true", help="Run only stage 4")
 
     # --- Stage 1 passthrough (bundle_to_yaml.py) ---
     s1 = parser.add_argument_group("stage 1: bundle_to_yaml")
@@ -159,13 +173,13 @@ Examples:
     s2.add_argument("--no-beta", action="store_true", default=False, help="Mark as not beta")
     s2.add_argument("--config", default="", help="JSON config file for stage 2")
 
-    # --- Stage 3 passthrough (Rust validator) ---
-    s3 = parser.add_argument_group("stage 3: validator")
-    s3.add_argument("--validator-wip", action="store_true", help="Pass --wip to validator")
-    s3.add_argument("--validator-local", action="store_true", help="Pass --local to validator")
-    s3.add_argument("--validator-strict-plugins", action="store_true",
+    # --- Stage 4 passthrough (Rust validator) ---
+    s4 = parser.add_argument_group("stage 4: validator")
+    s4.add_argument("--validator-wip", action="store_true", help="Pass --wip to validator")
+    s4.add_argument("--validator-local", action="store_true", help="Pass --local to validator")
+    s4.add_argument("--validator-strict-plugins", action="store_true",
                     help="Pass --strict-plugins to validator")
-    s3.add_argument("--validator-production", action="store_true",
+    s4.add_argument("--validator-production", action="store_true",
                     help="Pass --production to validator")
 
     return parser.parse_args()
@@ -173,8 +187,8 @@ Examples:
 
 def resolve_stages(args):
     """Determine which stages to run and validate required args."""
-    only_flags = [args.only_portable, args.only_configure, args.only_validate]
-    skip_flags = [args.skip_portable, args.skip_configure, args.skip_validate]
+    only_flags = [args.only_portable, args.only_configure, args.only_sync, args.only_validate]
+    skip_flags = [args.skip_portable, args.skip_configure, args.skip_sync, args.skip_validate]
 
     if any(only_flags) and any(skip_flags):
         print("Error: cannot combine --only-* and --skip-* flags", file=sys.stderr)
@@ -195,6 +209,8 @@ def resolve_stages(args):
     if args.only_configure:
         _require_stage2_args(args)
         return [("configure", build_configure_cmd)]
+    if args.only_sync:
+        return [("sync", build_sync_cmd)]
     if args.only_validate:
         return [("validate", build_validate_cmd)]
 
@@ -205,6 +221,8 @@ def resolve_stages(args):
     if not args.skip_configure:
         _require_stage2_args(args)
         stages.append(("configure", build_configure_cmd))
+    if not args.skip_sync and _cluster_env_set():
+        stages.append(("sync", build_sync_cmd))
     if not args.skip_validate:
         stages.append(("validate", build_validate_cmd))
 
@@ -213,6 +231,11 @@ def resolve_stages(args):
         sys.exit(2)
 
     return stages
+
+
+def _cluster_env_set():
+    """Return True if cluster env vars are configured."""
+    return bool(os.environ.get("BUNDLE_TESTING_CLUSTER"))
 
 
 def _merge_config_into_args(args):
@@ -254,11 +277,13 @@ def _apply_track(args):
     - 'auto': detects track from bundle state, then applies accordingly
     """
     # Skip track routing if an explicit --only-* flag was provided
-    if any([args.only_portable, args.only_configure, args.only_validate]):
+    if any([args.only_portable, args.only_configure, args.only_sync, args.only_validate]):
         return
 
     if args.track == "validate-only":
-        args.only_validate = True
+        # Skip stages 1 and 2, keep sync (if cluster env set) and validate
+        args.skip_portable = True
+        args.skip_configure = True
     elif args.track == "full":
         # Full pipeline — originals management happens here
         bundle_dir = os.path.join(REPO_ROOT, args.bundle_dir) if not os.path.isabs(args.bundle_dir) else args.bundle_dir
@@ -430,8 +455,23 @@ def build_configure_cmd(args):
     return cmd
 
 
+def build_sync_cmd(args):
+    """Build command for stage 3: sync_cluster_deps.py."""
+    cmd = [sys.executable, os.path.join(SCRIPTS_DIR, "sync_cluster_deps.py"),
+           "--bundle-dir", args.bundle_dir]
+
+    if args.verbose:
+        cmd.append("--verbose")
+    if args.json:
+        cmd.append("--json")
+    if args.dry_run:
+        cmd.append("--dry-run")
+
+    return cmd
+
+
 def build_validate_cmd(args, stage2_report=None):
-    """Build command for stage 3: Rust validator (cargo run)."""
+    """Build command for stage 4: Rust validator (cargo run)."""
     cmd = ["cargo", "run", "--"]
 
     if args.validator_wip:
@@ -489,6 +529,8 @@ def _print_stage_success(name, result):
             print(f"  ✓ {phases} phases completed | {modified} files modified, {created} created {duration}")
         else:
             print(f"  ✓ Configuration complete {duration}")
+    elif name == "sync":
+        print(f"  ✓ Cluster dependencies synced {duration}")
     elif name == "validate":
         print(f"  ✓ Validation passed {duration}")
 
@@ -496,7 +538,9 @@ def _print_stage_success(name, result):
 def print_summary(results, args):
     """Print final pipeline summary."""
     passed = sum(1 for r in results if r["status"] == "success")
-    failed = sum(1 for r in results if r["status"] == "error")
+    # Sync errors are non-blocking — don't count them as pipeline failures
+    failed = sum(1 for r in results if r["status"] == "error" and r["stage"] != "sync")
+    warned = sum(1 for r in results if r["status"] == "error" and r["stage"] == "sync")
     total = len(results)
 
     if args.json:

--- a/scripts/sync_cluster_deps.py
+++ b/scripts/sync_cluster_deps.py
@@ -426,8 +426,8 @@ def main():
         _output_report(args, skipped_reason="missing_credentials")
         sys.exit(0)
 
-    # Derive project name from bundle path
-    project_name = derive_project_name(bundle_dir)
+    # Derive project name from bundle path (use repo-relative path)
+    project_name = derive_project_name(os.path.relpath(bundle_dir, REPO_ROOT))
 
     if verbose:
         print(f"Target: {cluster} / project: {project_name}", file=sys.stderr)

--- a/scripts/sync_cluster_deps.py
+++ b/scripts/sync_cluster_deps.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""Sync missing functions/dictionaries to a Hydrolix cluster.
+
+Reads bundle.json to determine which functions and dictionaries are needed,
+queries the target cluster to see what already exists, and uploads any missing
+resources that have local files in the bundle directory.
+
+Designed to run as a pipeline stage between configure and validate.
+Skips silently if cluster env vars are not set.
+
+Usage:
+    python scripts/sync_cluster_deps.py \
+        --bundle-dir trafficpeak/bot-insights-cdn \
+        [--verbose] [--json] [--dry-run]
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+
+sys.path.insert(0, SCRIPTS_DIR)
+
+from configurator.constants import PREFIX_MAP
+
+HTTP_TIMEOUT = 120
+DATA_FILE_EXTENSIONS = ("csv", "yaml", "yml", "tsv")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Sync missing functions/dictionaries to a Hydrolix cluster.",
+    )
+    parser.add_argument(
+        "--bundle-dir", required=True,
+        help="Path to bundle directory (relative to repo root)",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--json", action="store_true", help="Output structured JSON report")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would be synced without uploading")
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _api_request(url, token, method="GET", body=None, content_type="application/json"):
+    """Make an authenticated API request. Returns parsed JSON or raises."""
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = content_type
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            resp_body = resp.read().decode("utf-8")
+            return json.loads(resp_body) if resp_body.strip() else {}
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8")[:500]
+        except Exception:
+            pass
+        raise RuntimeError(f"HTTP {e.code} {e.reason}: {error_body}") from e
+
+
+def _upload_multipart(url, token, field_name, file_name, file_bytes, mime_type):
+    """Upload a file via multipart/form-data POST."""
+    boundary = f"----SyncDeps{uuid.uuid4().hex}"
+    body = bytearray()
+
+    # name field
+    body.extend(f"--{boundary}\r\n".encode())
+    body.extend(f'Content-Disposition: form-data; name="name"\r\n\r\n'.encode())
+    stem = os.path.splitext(file_name)[0]
+    body.extend(f"{stem}\r\n".encode())
+
+    # file field
+    body.extend(f"--{boundary}\r\n".encode())
+    body.extend(
+        f'Content-Disposition: form-data; name="{field_name}"; filename="{file_name}"\r\n'.encode()
+    )
+    body.extend(f"Content-Type: {mime_type}\r\n\r\n".encode())
+    body.extend(file_bytes)
+    body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode())
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+    req = urllib.request.Request(url, data=bytes(body), headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            resp_body = resp.read().decode("utf-8")
+            try:
+                return json.loads(resp_body) if resp_body.strip() else {}
+            except json.JSONDecodeError:
+                return {}
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8")[:500]
+        except Exception:
+            pass
+        raise RuntimeError(f"HTTP {e.code} {e.reason}: {error_body}") from e
+
+
+def _extract_list(response_data, key_hints):
+    """Extract a list from an API response that may be an array or an object
+    with a known key containing the array (handles inconsistent Hydrolix API shapes)."""
+    if isinstance(response_data, list):
+        return response_data
+    if isinstance(response_data, dict):
+        for key in key_hints:
+            if key in response_data and isinstance(response_data[key], list):
+                return response_data[key]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Cluster interaction
+# ---------------------------------------------------------------------------
+
+def authenticate(cluster, username, password):
+    """Authenticate and return bearer token."""
+    url = f"https://{cluster}/config/v1/login"
+    body = json.dumps({"username": username, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8")[:500]
+        except Exception:
+            pass
+        raise RuntimeError(f"HTTP {e.code} {e.reason}: {error_body}") from e
+
+    if "auth_token" not in data or "access_token" not in data.get("auth_token", {}):
+        raise RuntimeError(f"Unexpected login response (no auth_token): {json.dumps(data)[:200]}")
+    return data["auth_token"]["access_token"]
+
+
+def find_org_uuid(cluster, token):
+    """Get the first org UUID from the cluster."""
+    url = f"https://{cluster}/config/v1/orgs/"
+    orgs = _api_request(url, token)
+    org_list = _extract_list(orgs, ["results", "data"])
+    if not org_list:
+        # Response might be the org directly or a single-item list
+        if isinstance(orgs, dict) and "uuid" in orgs:
+            return orgs["uuid"]
+        raise RuntimeError("No organizations found on cluster")
+    return org_list[0]["uuid"]
+
+
+def find_or_create_project(cluster, token, org_uuid, project_name):
+    """Find a project by name, or create it. Returns (uuid, created_bool)."""
+    url = f"https://{cluster}/config/v1/orgs/{org_uuid}/projects/"
+    projects = _api_request(url, token)
+    project_list = _extract_list(projects, ["results", "data"])
+
+    for proj in project_list:
+        if proj.get("name") == project_name:
+            return proj["uuid"], False
+
+    # Create the project (handle 409 race condition from parallel runs)
+    body = {"name": project_name, "description": "Auto-created by sync_cluster_deps for bundle testing"}
+    try:
+        result = _api_request(url, token, method="POST", body=body)
+        return result["uuid"], True
+    except RuntimeError as e:
+        if "409" in str(e):
+            # Another process created the project — re-fetch
+            projects = _api_request(url, token)
+            project_list = _extract_list(projects, ["results", "data"])
+            for proj in project_list:
+                if proj.get("name") == project_name:
+                    return proj["uuid"], False
+        raise
+
+
+def list_existing_resources(cluster, token, org_uuid, proj_uuid, resource_type):
+    """List existing functions or dictionaries on the cluster.
+    Returns a set of base names (with project prefix stripped)."""
+    url = f"https://{cluster}/config/v1/orgs/{org_uuid}/projects/{proj_uuid}/{resource_type}/"
+    response = _api_request(url, token)
+    items = _extract_list(response, ["results", resource_type, "data"])
+    names = set()
+    for item in items:
+        name = item.get("name", "") if isinstance(item, dict) else ""
+        if name:
+            names.add(name)
+    return names
+
+
+def strip_project_prefix(names, project_name):
+    """Given a set of names that may be prefixed with '{project_name}_',
+    return a set of base names (both prefixed and unprefixed forms)."""
+    base_names = set()
+    prefix = f"{project_name}_"
+    for name in names:
+        base_names.add(name)
+        if name.startswith(prefix):
+            base_names.add(name[len(prefix):])
+    return base_names
+
+
+# ---------------------------------------------------------------------------
+# Dependency collection
+# ---------------------------------------------------------------------------
+
+def collect_dependencies(bundle_json_path):
+    """Read bundle.json and return (functions_needed, dictionaries_needed) as sets."""
+    with open(bundle_json_path, "r", encoding="utf-8") as f:
+        bundle = json.load(f)
+
+    deps = bundle.get("dependencies", {}).get("hydrolix", {})
+    functions = set()
+    dictionaries = set()
+
+    for key in ("required_functions", "shared_functions"):
+        functions.update(deps.get(key) or [])
+    for key in ("required_dictionaries", "shared_dictionaries"):
+        dictionaries.update(deps.get(key) or [])
+
+    return functions, dictionaries
+
+
+# ---------------------------------------------------------------------------
+# Local file discovery
+# ---------------------------------------------------------------------------
+
+def find_local_function(bundle_dir, name):
+    """Look for a function JSON file in the bundle. Returns path or None."""
+    for subdir in ("functions/.extracted", "functions"):
+        path = os.path.join(bundle_dir, subdir, f"{name}.json")
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def find_local_dictionary(bundle_dir, name):
+    """Look for a dictionary definition + data file in the bundle.
+    Returns (definition_path, data_path) or None.
+
+    Handles two layouts:
+    1. Flat: dictionaries/{name}.json + dictionaries/{name}.csv
+    2. Subdirectory: dictionaries/{name}/schema_definition.json + dictionaries/{name}/{name}.csv
+    """
+    for subdir in ("dictionaries/.extracted", "dictionaries"):
+        base = os.path.join(bundle_dir, subdir)
+
+        # Layout 1: flat files
+        json_path = os.path.join(base, f"{name}.json")
+        if os.path.isfile(json_path):
+            for ext in DATA_FILE_EXTENSIONS:
+                data_path = os.path.join(base, f"{name}.{ext}")
+                if os.path.isfile(data_path):
+                    return json_path, data_path
+
+        # Layout 2: subdirectory with schema_definition.json
+        subdir_path = os.path.join(base, name)
+        schema_path = os.path.join(subdir_path, "schema_definition.json")
+        if os.path.isfile(schema_path):
+            # Try exact name match first
+            for ext in DATA_FILE_EXTENSIONS:
+                data_path = os.path.join(subdir_path, f"{name}.{ext}")
+                if os.path.isfile(data_path):
+                    return schema_path, data_path
+            # Fall back: scan for any data file with a matching extension
+            if os.path.isdir(subdir_path):
+                for entry in os.listdir(subdir_path):
+                    if any(entry.endswith(f".{ext}") for ext in DATA_FILE_EXTENSIONS):
+                        return schema_path, os.path.join(subdir_path, entry)
+
+    return None
+
+
+def _build_dict_definition(schema_path, name):
+    """Build a dictionary definition payload from either a full definition JSON
+    or a schema_definition.json (array of columns)."""
+    with open(schema_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Full definition: has 'name' and 'settings' keys
+    if isinstance(data, dict) and "settings" in data:
+        data["name"] = name
+        return data
+
+    # Schema-only: array of column definitions — wrap into full definition
+    if isinstance(data, list):
+        return {
+            "name": name,
+            "settings": {
+                "filename": name,
+                "output_columns": data,
+            },
+        }
+
+    raise ValueError(f"Unexpected dictionary definition format in {schema_path}")
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+def upload_function(cluster, token, org_uuid, proj_uuid, project_name, name, json_path):
+    """Upload a function to the cluster. Returns True on success."""
+    with open(json_path, "r", encoding="utf-8") as f:
+        func_def = json.load(f)
+
+    # Replace __PROJECT_NAME__ in SQL
+    if "sql" in func_def:
+        func_def["sql"] = func_def["sql"].replace("__PROJECT_NAME__", project_name)
+    func_def["name"] = name
+
+    url = f"https://{cluster}/config/v1/orgs/{org_uuid}/projects/{proj_uuid}/functions/"
+    _api_request(url, token, method="POST", body=func_def)
+    return True
+
+
+def upload_dictionary(cluster, token, org_uuid, proj_uuid, project_name, name, def_path, data_path):
+    """Upload a dictionary (data file first, then definition). Returns True on success."""
+    # Upload data file
+    data_file_name = os.path.basename(data_path)
+    ext = os.path.splitext(data_file_name)[1].lower().lstrip(".")
+    mime_type = "application/x-yaml" if ext in ("yaml", "yml") else "text/csv"
+
+    with open(data_path, "rb") as f:
+        file_bytes = f.read()
+
+    files_url = f"https://{cluster}/config/v1/orgs/{org_uuid}/projects/{proj_uuid}/dictionaries/files/"
+    _upload_multipart(files_url, token, "file", data_file_name, file_bytes, mime_type)
+
+    # Upload definition
+    definition = _build_dict_definition(def_path, name)
+    dict_url = f"https://{cluster}/config/v1/orgs/{org_uuid}/projects/{proj_uuid}/dictionaries/"
+    _api_request(dict_url, token, method="POST", body=definition)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def derive_project_name(bundle_dir):
+    """Derive the cluster project name from the bundle path.
+    aws/* -> commons, trafficpeak/* -> akamai."""
+    # Normalize: strip leading/trailing slashes
+    parts = bundle_dir.strip("/").split("/")
+    vendor = parts[0] if parts else ""
+    project = PREFIX_MAP.get(vendor)
+    if not project:
+        raise ValueError(
+            f"Cannot derive project name from bundle path '{bundle_dir}'. "
+            f"Expected path starting with one of: {', '.join(PREFIX_MAP.keys())}"
+        )
+    return project
+
+
+def main():
+    args = parse_args()
+    verbose = args.verbose
+    dry_run = args.dry_run
+
+    # Resolve bundle directory
+    bundle_dir = args.bundle_dir
+    if not os.path.isabs(bundle_dir):
+        bundle_dir = os.path.join(REPO_ROOT, bundle_dir)
+
+    bundle_json_path = os.path.join(bundle_dir, "bundle.json")
+    if not os.path.isfile(bundle_json_path):
+        print("No bundle.json found — skipping dependency sync", file=sys.stderr)
+        sys.exit(0)
+
+    # Collect dependencies
+    functions_needed, dicts_needed = collect_dependencies(bundle_json_path)
+    if not functions_needed and not dicts_needed:
+        if verbose:
+            print("No dependencies declared — nothing to sync", file=sys.stderr)
+        _output_report(args, skipped_reason="no_dependencies")
+        sys.exit(0)
+
+    if verbose:
+        print(f"Dependencies needed: {len(functions_needed)} function(s), "
+              f"{len(dicts_needed)} dictionary(s)", file=sys.stderr)
+
+    # Check env vars
+    cluster = os.environ.get("BUNDLE_TESTING_CLUSTER", "")
+    username = os.environ.get("BUNDLE_TESTING_USERNAME", "")
+    password = os.environ.get("BUNDLE_TESTING_PASSWORD", "")
+
+    if not cluster:
+        if verbose:
+            print("BUNDLE_TESTING_CLUSTER not set — skipping dependency sync", file=sys.stderr)
+        _output_report(args, skipped_reason="no_cluster_env")
+        sys.exit(0)
+
+    if not username or not password:
+        missing = []
+        if not username:
+            missing.append("BUNDLE_TESTING_USERNAME")
+        if not password:
+            missing.append("BUNDLE_TESTING_PASSWORD")
+        print(f"BUNDLE_TESTING_CLUSTER is set but {', '.join(missing)} missing — "
+              f"skipping dependency sync", file=sys.stderr)
+        _output_report(args, skipped_reason="missing_credentials")
+        sys.exit(0)
+
+    # Derive project name from bundle path
+    project_name = derive_project_name(bundle_dir)
+
+    if verbose:
+        print(f"Target: {cluster} / project: {project_name}", file=sys.stderr)
+
+    # Authenticate
+    try:
+        token = authenticate(cluster, username, password)
+    except Exception as e:
+        print(f"Authentication failed: {e}", file=sys.stderr)
+        _output_report(args, error=f"auth_failed: {e}")
+        sys.exit(1)
+
+    if verbose:
+        print("Authenticated successfully", file=sys.stderr)
+
+    # Resolve org and project
+    try:
+        org_uuid = find_org_uuid(cluster, token)
+        proj_uuid, proj_created = find_or_create_project(cluster, token, org_uuid, project_name)
+        if verbose:
+            if proj_created:
+                print(f"Created project '{project_name}' ({proj_uuid})", file=sys.stderr)
+            else:
+                print(f"Found project '{project_name}' ({proj_uuid})", file=sys.stderr)
+    except Exception as e:
+        print(f"Failed to resolve org/project: {e}", file=sys.stderr)
+        _output_report(args, error=f"project_resolution_failed: {e}")
+        sys.exit(1)
+
+    # List existing resources
+    try:
+        existing_funcs = list_existing_resources(cluster, token, org_uuid, proj_uuid, "functions")
+        existing_dicts = list_existing_resources(cluster, token, org_uuid, proj_uuid, "dictionaries")
+    except Exception as e:
+        print(f"Failed to list existing resources: {e}", file=sys.stderr)
+        _output_report(args, error=f"list_failed: {e}")
+        sys.exit(1)
+
+    existing_func_bases = strip_project_prefix(existing_funcs, project_name)
+    existing_dict_bases = strip_project_prefix(existing_dicts, project_name)
+
+    # Diff
+    missing_funcs = functions_needed - existing_func_bases
+    missing_dicts = dicts_needed - existing_dict_bases
+    present_funcs = functions_needed - missing_funcs
+    present_dicts = dicts_needed - missing_dicts
+
+    if not missing_funcs and not missing_dicts:
+        if verbose:
+            print("All dependencies already present on cluster", file=sys.stderr)
+        _output_report(args, present_funcs=present_funcs, present_dicts=present_dicts)
+        sys.exit(0)
+
+    if verbose:
+        if missing_funcs:
+            print(f"Missing functions: {', '.join(sorted(missing_funcs))}", file=sys.stderr)
+        if missing_dicts:
+            print(f"Missing dictionaries: {', '.join(sorted(missing_dicts))}", file=sys.stderr)
+
+    # Discover local files and categorize
+    uploadable_funcs = {}   # name -> path
+    uploadable_dicts = {}   # name -> (def_path, data_path)
+    warn_funcs = []
+    warn_dicts = []
+
+    for name in sorted(missing_funcs):
+        path = find_local_function(bundle_dir, name)
+        if path:
+            uploadable_funcs[name] = path
+        else:
+            warn_funcs.append(name)
+
+    for name in sorted(missing_dicts):
+        result = find_local_dictionary(bundle_dir, name)
+        if result:
+            uploadable_dicts[name] = result
+        else:
+            warn_dicts.append(name)
+
+    # Report warnings
+    if warn_funcs:
+        print(f"Warning: {len(warn_funcs)} function(s) missing on cluster with no local files:",
+              file=sys.stderr)
+        for name in warn_funcs:
+            print(f"  - {name}", file=sys.stderr)
+
+    if warn_dicts:
+        print(f"Warning: {len(warn_dicts)} dictionary(s) missing on cluster with no local files:",
+              file=sys.stderr)
+        for name in warn_dicts:
+            print(f"  - {name}", file=sys.stderr)
+
+    if dry_run:
+        if uploadable_dicts:
+            print(f"[dry-run] Would upload {len(uploadable_dicts)} dictionary(s):",
+                  file=sys.stderr)
+            for name in uploadable_dicts:
+                print(f"  - {name}", file=sys.stderr)
+        if uploadable_funcs:
+            print(f"[dry-run] Would upload {len(uploadable_funcs)} function(s):",
+                  file=sys.stderr)
+            for name in uploadable_funcs:
+                print(f"  - {name}", file=sys.stderr)
+        _output_report(
+            args, present_funcs=present_funcs, present_dicts=present_dicts,
+            uploadable_funcs=uploadable_funcs, uploadable_dicts=uploadable_dicts,
+            warn_funcs=warn_funcs, warn_dicts=warn_dicts, dry_run=True,
+        )
+        sys.exit(0)
+
+    # Upload — dictionaries first (functions may depend on them)
+    uploaded_dicts = []
+    failed_dicts = []
+    for name, (def_path, data_path) in uploadable_dicts.items():
+        try:
+            upload_dictionary(cluster, token, org_uuid, proj_uuid, project_name,
+                              name, def_path, data_path)
+            uploaded_dicts.append(name)
+            if verbose:
+                print(f"  Uploaded dictionary: {name}", file=sys.stderr)
+        except Exception as e:
+            failed_dicts.append((name, str(e)))
+            print(f"  Warning: failed to upload dictionary '{name}': {e}", file=sys.stderr)
+
+    uploaded_funcs = []
+    failed_funcs = []
+    for name, path in uploadable_funcs.items():
+        try:
+            upload_function(cluster, token, org_uuid, proj_uuid, project_name, name, path)
+            uploaded_funcs.append(name)
+            if verbose:
+                print(f"  Uploaded function: {name}", file=sys.stderr)
+        except Exception as e:
+            failed_funcs.append((name, str(e)))
+            print(f"  Warning: failed to upload function '{name}': {e}", file=sys.stderr)
+
+    # Summary
+    _output_report(
+        args, present_funcs=present_funcs, present_dicts=present_dicts,
+        uploaded_funcs=uploaded_funcs, uploaded_dicts=uploaded_dicts,
+        failed_funcs=failed_funcs, failed_dicts=failed_dicts,
+        warn_funcs=warn_funcs, warn_dicts=warn_dicts,
+    )
+
+    # Print human-readable summary to stderr
+    total_uploaded = len(uploaded_funcs) + len(uploaded_dicts)
+    total_failed = len(failed_funcs) + len(failed_dicts)
+    total_warned = len(warn_funcs) + len(warn_dicts)
+
+    parts = []
+    if total_uploaded:
+        parts.append(f"{total_uploaded} uploaded")
+    if present_funcs or present_dicts:
+        parts.append(f"{len(present_funcs) + len(present_dicts)} already present")
+    if total_warned:
+        parts.append(f"{total_warned} not found locally")
+    if total_failed:
+        parts.append(f"{total_failed} failed")
+
+    print(f"Sync complete: {', '.join(parts)}", file=sys.stderr)
+
+
+def _output_report(args, **kwargs):
+    """Output structured JSON report to stdout if --json is set."""
+    if not args.json:
+        return
+
+    report = {"stage": "sync"}
+
+    if "skipped_reason" in kwargs:
+        report["status"] = "skipped"
+        report["reason"] = kwargs["skipped_reason"]
+    elif "error" in kwargs:
+        report["status"] = "error"
+        report["error"] = kwargs["error"]
+    else:
+        report["status"] = "success"
+        report["present"] = {
+            "functions": sorted(kwargs.get("present_funcs") or []),
+            "dictionaries": sorted(kwargs.get("present_dicts") or []),
+        }
+
+        if kwargs.get("dry_run"):
+            report["would_upload"] = {
+                "functions": sorted(kwargs.get("uploadable_funcs") or {}),
+                "dictionaries": sorted(kwargs.get("uploadable_dicts") or {}),
+            }
+        else:
+            report["uploaded"] = {
+                "functions": kwargs.get("uploaded_funcs", []),
+                "dictionaries": kwargs.get("uploaded_dicts", []),
+            }
+            report["failed"] = {
+                "functions": [{"name": n, "error": e}
+                              for n, e in (kwargs.get("failed_funcs") or [])],
+                "dictionaries": [{"name": n, "error": e}
+                                 for n, e in (kwargs.get("failed_dicts") or [])],
+            }
+
+        report["not_found_locally"] = {
+            "functions": sorted(kwargs.get("warn_funcs") or []),
+            "dictionaries": sorted(kwargs.get("warn_dicts") or []),
+        }
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nSync cancelled.", file=sys.stderr)
+        sys.exit(130)

--- a/scripts/sync_cluster_deps.py
+++ b/scripts/sync_cluster_deps.py
@@ -155,7 +155,10 @@ def authenticate(cluster, username, password):
         raise RuntimeError(f"HTTP {e.code} {e.reason}: {error_body}") from e
 
     if "auth_token" not in data or "access_token" not in data.get("auth_token", {}):
-        raise RuntimeError(f"Unexpected login response (no auth_token): {json.dumps(data)[:200]}")
+        raise RuntimeError(
+            f"Unexpected login response (no auth_token); "
+            f"response keys: {', '.join(data.keys()) if isinstance(data, dict) else type(data).__name__}"
+        )
     return data["auth_token"]["access_token"]
 
 
@@ -188,7 +191,8 @@ def find_or_create_project(cluster, token, org_uuid, project_name):
         result = _api_request(url, token, method="POST", body=body)
         return result["uuid"], True
     except RuntimeError as e:
-        if "409" in str(e):
+        cause = e.__cause__
+        if isinstance(cause, urllib.error.HTTPError) and cause.code == 409:
             # Another process created the project — re-fetch
             projects = _api_request(url, token)
             project_list = _extract_list(projects, ["results", "data"])
@@ -368,6 +372,10 @@ def derive_project_name(bundle_dir):
     # Normalize: strip leading/trailing slashes
     parts = bundle_dir.strip("/").split("/")
     vendor = parts[0] if parts else ""
+    if vendor == "..":
+        raise ValueError(
+            f"Bundle path '{bundle_dir}' is outside the repository root."
+        )
     project = PREFIX_MAP.get(vendor)
     if not project:
         raise ValueError(

--- a/tests/test_run_pipeline_track.py
+++ b/tests/test_run_pipeline_track.py
@@ -12,8 +12,9 @@ from scripts.run_pipeline import parse_args, resolve_stages, _apply_track, REPO_
 class TestTrackFlag:
     """Tests for --track flag behavior in the pipeline orchestrator."""
 
-    def test_track_validate_only_forces_only_validate(self, monkeypatch):
-        """--track validate-only should force --only-validate, running only Stage 3."""
+    def test_track_validate_only_skips_portable_and_configure(self, monkeypatch):
+        """--track validate-only should skip stages 1 and 2, keeping sync (if env set) and validate."""
+        monkeypatch.delenv("BUNDLE_TESTING_CLUSTER", raising=False)
         monkeypatch.setattr(
             "sys.argv",
             ["run_pipeline.py", "--bundle-dir", "aws/test-bundle", "--track", "validate-only"],
@@ -22,7 +23,8 @@ class TestTrackFlag:
         assert args.track == "validate-only"
 
         _apply_track(args)
-        assert args.only_validate is True
+        assert args.skip_portable is True
+        assert args.skip_configure is True
 
         stages = resolve_stages(args)
         stage_names = [name for name, _ in stages]
@@ -119,7 +121,8 @@ class TestTrackFlag:
         _apply_track(args)
 
         assert args.track == "validate-only"
-        assert args.only_validate is True
+        assert args.skip_portable is True
+        assert args.skip_configure is True
 
     def test_track_auto_raw_bundle_with_config_routes_full(self, tmp_path, monkeypatch):
         """--track auto on a raw bundle with bundle-config.json (first run) → full pipeline."""

--- a/tests/test_sync_cluster_deps.py
+++ b/tests/test_sync_cluster_deps.py
@@ -98,6 +98,10 @@ class TestDeriveProjectName:
     def test_strips_leading_slashes(self):
         assert derive_project_name("/aws/foo") == "commons"
 
+    def test_outside_repo_path_raises(self):
+        with pytest.raises(ValueError, match="outside the repository root"):
+            derive_project_name("../../aws/cdn-insights")
+
     def test_unknown_vendor_raises(self):
         with pytest.raises(ValueError, match="Cannot derive project name"):
             derive_project_name("azure/something")

--- a/tests/test_sync_cluster_deps.py
+++ b/tests/test_sync_cluster_deps.py
@@ -336,6 +336,18 @@ class TestPipelineIntegration:
         stage_names = [name for name, _ in stages]
         assert stage_names == ["sync"]
 
+    def test_only_sync_dry_run(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--only-sync", "--dry-run"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages
+        args = parse_args()
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert stage_names == ["sync"]
+
     def test_validate_only_track_includes_sync_when_env_set(self, monkeypatch):
         monkeypatch.setenv("BUNDLE_TESTING_CLUSTER", "test.cluster.dev")
         monkeypatch.setattr(

--- a/tests/test_sync_cluster_deps.py
+++ b/tests/test_sync_cluster_deps.py
@@ -1,0 +1,368 @@
+"""Tests for sync_cluster_deps.py — cluster dependency sync stage."""
+
+import json
+import os
+import sys
+import types
+
+import pytest
+
+# Stub out utils.file_utils before importing scripts modules
+_utils_pkg = types.ModuleType("utils")
+_utils_pkg.file_utils = types.ModuleType("utils.file_utils")
+
+
+def _stub_read_json(path, *a, **kw):
+    with open(path) as f:
+        return json.load(f)
+
+
+_utils_pkg.file_utils.read_json = _stub_read_json
+_utils_pkg.file_utils.write_json = lambda *a, **kw: None
+sys.modules.setdefault("utils", _utils_pkg)
+sys.modules.setdefault("utils.file_utils", _utils_pkg.file_utils)
+
+from scripts.sync_cluster_deps import (
+    collect_dependencies,
+    derive_project_name,
+    find_local_function,
+    find_local_dictionary,
+    strip_project_prefix,
+    _build_dict_definition,
+    _extract_list,
+)
+
+
+# ---------------------------------------------------------------------------
+# collect_dependencies
+# ---------------------------------------------------------------------------
+
+class TestCollectDependencies:
+    def test_collects_all_four_arrays(self, tmp_path):
+        bundle_json = tmp_path / "bundle.json"
+        bundle_json.write_text(json.dumps({
+            "dependencies": {
+                "hydrolix": {
+                    "required_functions": ["func_a"],
+                    "shared_functions": ["func_b", "func_c"],
+                    "required_dictionaries": ["dict_a"],
+                    "shared_dictionaries": ["dict_b"],
+                }
+            }
+        }))
+        funcs, dicts = collect_dependencies(str(bundle_json))
+        assert funcs == {"func_a", "func_b", "func_c"}
+        assert dicts == {"dict_a", "dict_b"}
+
+    def test_handles_empty_deps(self, tmp_path):
+        bundle_json = tmp_path / "bundle.json"
+        bundle_json.write_text(json.dumps({
+            "dependencies": {"hydrolix": {}}
+        }))
+        funcs, dicts = collect_dependencies(str(bundle_json))
+        assert funcs == set()
+        assert dicts == set()
+
+    def test_handles_missing_hydrolix_key(self, tmp_path):
+        bundle_json = tmp_path / "bundle.json"
+        bundle_json.write_text(json.dumps({"dependencies": {}}))
+        funcs, dicts = collect_dependencies(str(bundle_json))
+        assert funcs == set()
+        assert dicts == set()
+
+    def test_deduplicates_across_required_and_shared(self, tmp_path):
+        bundle_json = tmp_path / "bundle.json"
+        bundle_json.write_text(json.dumps({
+            "dependencies": {
+                "hydrolix": {
+                    "required_functions": ["city_name"],
+                    "shared_functions": ["city_name", "breadcrumbs"],
+                }
+            }
+        }))
+        funcs, _ = collect_dependencies(str(bundle_json))
+        assert funcs == {"city_name", "breadcrumbs"}
+
+
+# ---------------------------------------------------------------------------
+# derive_project_name
+# ---------------------------------------------------------------------------
+
+class TestDeriveProjectName:
+    def test_aws_maps_to_commons(self):
+        assert derive_project_name("aws/cdn-insights") == "commons"
+
+    def test_trafficpeak_maps_to_akamai(self):
+        assert derive_project_name("trafficpeak/bot-insights-cdn") == "akamai"
+
+    def test_strips_leading_slashes(self):
+        assert derive_project_name("/aws/foo") == "commons"
+
+    def test_unknown_vendor_raises(self):
+        with pytest.raises(ValueError, match="Cannot derive project name"):
+            derive_project_name("azure/something")
+
+
+# ---------------------------------------------------------------------------
+# strip_project_prefix
+# ---------------------------------------------------------------------------
+
+class TestStripProjectPrefix:
+    def test_strips_prefix(self):
+        existing = {"commons_city_name", "commons_breadcrumbs"}
+        bases = strip_project_prefix(existing, "commons")
+        assert "city_name" in bases
+        assert "breadcrumbs" in bases
+        # Also keeps the full name
+        assert "commons_city_name" in bases
+
+    def test_handles_unprefixed_names(self):
+        existing = {"city_name"}
+        bases = strip_project_prefix(existing, "commons")
+        assert "city_name" in bases
+
+    def test_mixed_prefixed_and_unprefixed(self):
+        existing = {"commons_func_a", "func_b"}
+        bases = strip_project_prefix(existing, "commons")
+        assert "func_a" in bases
+        assert "func_b" in bases
+
+
+# ---------------------------------------------------------------------------
+# find_local_function
+# ---------------------------------------------------------------------------
+
+class TestFindLocalFunction:
+    def test_finds_json_in_functions_dir(self, tmp_path):
+        funcs_dir = tmp_path / "functions"
+        funcs_dir.mkdir()
+        func_file = funcs_dir / "city_name.json"
+        func_file.write_text(json.dumps({"name": "city_name", "sql": "() -> 1"}))
+
+        result = find_local_function(str(tmp_path), "city_name")
+        assert result == str(func_file)
+
+    def test_finds_json_in_extracted_dir(self, tmp_path):
+        extracted = tmp_path / "functions" / ".extracted"
+        extracted.mkdir(parents=True)
+        func_file = extracted / "my_func.json"
+        func_file.write_text(json.dumps({"name": "my_func", "sql": "() -> 1"}))
+
+        result = find_local_function(str(tmp_path), "my_func")
+        assert result == str(func_file)
+
+    def test_returns_none_when_missing(self, tmp_path):
+        result = find_local_function(str(tmp_path), "nonexistent")
+        assert result is None
+
+    def test_ignores_sql_files(self, tmp_path):
+        """Only .json files are uploadable — .sql files are raw assets."""
+        funcs_dir = tmp_path / "functions"
+        funcs_dir.mkdir()
+        (funcs_dir / "breadcrumbs.sql").write_text("(x) -> x")
+
+        result = find_local_function(str(tmp_path), "breadcrumbs")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find_local_dictionary
+# ---------------------------------------------------------------------------
+
+class TestFindLocalDictionary:
+    def test_finds_flat_json_plus_csv(self, tmp_path):
+        dicts_dir = tmp_path / "dictionaries"
+        dicts_dir.mkdir()
+        (dicts_dir / "geoip.json").write_text(json.dumps({
+            "name": "geoip", "settings": {"filename": "geoip"}
+        }))
+        (dicts_dir / "geoip.csv").write_text("network,asn\n1.0.0.0/8,13335")
+
+        result = find_local_dictionary(str(tmp_path), "geoip")
+        assert result is not None
+        assert result[0].endswith("geoip.json")
+        assert result[1].endswith("geoip.csv")
+
+    def test_finds_subdirectory_schema_layout(self, tmp_path):
+        subdir = tmp_path / "dictionaries" / "geoip_asn"
+        subdir.mkdir(parents=True)
+        (subdir / "schema_definition.json").write_text(json.dumps([
+            {"name": "network", "datatype": {"type": "string"}}
+        ]))
+        (subdir / "geoip_asn.csv").write_text("network\n1.0.0.0/8")
+
+        result = find_local_dictionary(str(tmp_path), "geoip_asn")
+        assert result is not None
+        assert result[0].endswith("schema_definition.json")
+        assert result[1].endswith("geoip_asn.csv")
+
+    def test_returns_none_when_no_data_file(self, tmp_path):
+        dicts_dir = tmp_path / "dictionaries"
+        dicts_dir.mkdir()
+        (dicts_dir / "lonely.json").write_text(json.dumps({"name": "lonely", "settings": {}}))
+
+        result = find_local_dictionary(str(tmp_path), "lonely")
+        assert result is None
+
+    def test_returns_none_when_missing(self, tmp_path):
+        result = find_local_dictionary(str(tmp_path), "nonexistent")
+        assert result is None
+
+    def test_finds_yaml_data_file(self, tmp_path):
+        dicts_dir = tmp_path / "dictionaries"
+        dicts_dir.mkdir()
+        (dicts_dir / "ua_cat.json").write_text(json.dumps({
+            "name": "ua_cat", "settings": {"filename": "ua_cat"}
+        }))
+        (dicts_dir / "ua_cat.yml").write_text("key: value")
+
+        result = find_local_dictionary(str(tmp_path), "ua_cat")
+        assert result is not None
+        assert result[1].endswith("ua_cat.yml")
+
+
+# ---------------------------------------------------------------------------
+# _build_dict_definition
+# ---------------------------------------------------------------------------
+
+class TestBuildDictDefinition:
+    def test_full_definition_preserves_settings(self, tmp_path):
+        defn = {
+            "name": "old_name",
+            "settings": {
+                "filename": "geoip",
+                "layout": "ip_trie",
+                "output_columns": [{"name": "net", "datatype": {"type": "string"}}],
+            }
+        }
+        path = tmp_path / "def.json"
+        path.write_text(json.dumps(defn))
+
+        result = _build_dict_definition(str(path), "new_name")
+        assert result["name"] == "new_name"
+        assert result["settings"]["layout"] == "ip_trie"
+
+    def test_schema_array_wrapped(self, tmp_path):
+        schema = [
+            {"name": "network", "datatype": {"type": "string"}},
+            {"name": "asn", "datatype": {"type": "uint32"}},
+        ]
+        path = tmp_path / "schema_definition.json"
+        path.write_text(json.dumps(schema))
+
+        result = _build_dict_definition(str(path), "my_dict")
+        assert result["name"] == "my_dict"
+        assert result["settings"]["filename"] == "my_dict"
+        assert len(result["settings"]["output_columns"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# _extract_list
+# ---------------------------------------------------------------------------
+
+class TestExtractList:
+    def test_direct_array(self):
+        assert _extract_list([1, 2, 3], []) == [1, 2, 3]
+
+    def test_object_with_results_key(self):
+        assert _extract_list({"results": [1, 2]}, ["results"]) == [1, 2]
+
+    def test_object_with_functions_key(self):
+        assert _extract_list({"functions": [{"name": "a"}]}, ["functions"]) == [{"name": "a"}]
+
+    def test_object_with_data_key(self):
+        assert _extract_list({"data": [1]}, ["results", "data"]) == [1]
+
+    def test_empty_fallback(self):
+        assert _extract_list({"unknown": [1]}, ["results"]) == []
+
+    def test_none_in_dict(self):
+        assert _extract_list({"results": None}, ["results"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration (run_pipeline.py)
+# ---------------------------------------------------------------------------
+
+class TestPipelineIntegration:
+    def test_sync_stage_included_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("BUNDLE_TESTING_CLUSTER", "test.cluster.dev")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--table-name", "t", "--data-category", "cdn"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages
+        args = parse_args()
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert "sync" in stage_names
+        assert stage_names.index("sync") < stage_names.index("validate")
+
+    def test_sync_stage_excluded_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("BUNDLE_TESTING_CLUSTER", raising=False)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--table-name", "t", "--data-category", "cdn"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages
+        args = parse_args()
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert "sync" not in stage_names
+
+    def test_skip_sync_flag(self, monkeypatch):
+        monkeypatch.setenv("BUNDLE_TESTING_CLUSTER", "test.cluster.dev")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--table-name", "t", "--data-category", "cdn", "--skip-sync"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages
+        args = parse_args()
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert "sync" not in stage_names
+
+    def test_only_sync_flag(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle", "--only-sync"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages
+        args = parse_args()
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert stage_names == ["sync"]
+
+    def test_validate_only_track_includes_sync_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("BUNDLE_TESTING_CLUSTER", "test.cluster.dev")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--track", "validate-only"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages, _apply_track
+        args = parse_args()
+        _apply_track(args)
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert "sync" in stage_names
+        assert "validate" in stage_names
+        assert "portable" not in stage_names
+        assert "configure" not in stage_names
+
+    def test_validate_only_track_without_env_skips_sync(self, monkeypatch):
+        monkeypatch.delenv("BUNDLE_TESTING_CLUSTER", raising=False)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["run_pipeline.py", "--bundle-dir", "aws/test-bundle",
+             "--track", "validate-only"],
+        )
+        from scripts.run_pipeline import parse_args, resolve_stages, _apply_track
+        args = parse_args()
+        _apply_track(args)
+        stages = resolve_stages(args)
+        stage_names = [name for name, _ in stages]
+        assert stage_names == ["validate"]


### PR DESCRIPTION
## Summary

- Adds `scripts/sync_cluster_deps.py` as a new pipeline stage (Stage 3) between configure and validate
- When `BUNDLE_TESTING_CLUSTER` env vars are set, reads bundle.json dependencies, diffs against cluster inventory via the config API, and uploads missing functions/dictionaries from local bundle files
- Non-blocking: warns on failure, never stops the pipeline. Skips silently when no cluster env vars are configured
- Targets vendor-specific projects (`aws/*` → `commons`, `trafficpeak/*` → `akamai`), creating them if absent
- Uploads dictionaries before functions to respect dependency order
- New `--skip-sync` / `--only-sync` flags in `run_pipeline.py`
- Runs on both full and validate-only tracks
- 34 new tests covering dependency collection, file discovery, project derivation, pipeline integration

## Test plan

- [ ] `python3 -m pytest tests/test_sync_cluster_deps.py -v` — all 34 tests pass
- [ ] `python3 -m pytest tests/ -v` — all 90 tests pass (no regressions)
- [ ] Verify sync stage skips silently when `BUNDLE_TESTING_CLUSTER` is unset
- [ ] Verify `--only-sync --dry-run` reports what would be synced without uploading
- [ ] Live test against a dev cluster with a bundle that has local functions/dictionaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)