### PR TITLE
LOTC-1241: alert #solutions-bundles-alerts on bundle request PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,6 +69,14 @@ Or via GitHub UI: **Actions → push-to-cac-tools → Run workflow**
 
 ---
 
+### `bundle-request-alert`
+
+**Trigger:** Pull requests opened against `main` with the `bundle request` label, or when the `bundle request` label is added to an existing PR.
+
+Sends a Slack notification to `#solutions-bundles-alerts` with the PR title, author, and link. Uses the same `bundle-runbook-env` environment and AWS Secrets Manager infrastructure as `publish-runbook` — no additional secrets required.
+
+---
+
 ### `publish-runbook`
 
 **Trigger:** Pushes to `main` that modify `aws/**/bundle.json` or `trafficpeak/**/bundle.json`; also supports manual dispatch.

--- a/.github/workflows/bundle-request-alert.yml
+++ b/.github/workflows/bundle-request-alert.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    # labeled: fires when "bundle request" is added to any open PR
+    # opened:  fires when a PR is created with the label already applied
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'bundle request') ||
       (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'bundle request'))
@@ -23,19 +25,15 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Load secrets from AWS Secrets Manager
+      - name: Load Slack webhook from AWS Secrets Manager
         run: |
-          secrets=$(aws secretsmanager get-secret-value \
+          webhook_url=$(aws secretsmanager get-secret-value \
             --secret-id "${{ vars.AWS_SECRET_ARN }}" \
             --query SecretString \
-            --output text)
+            --output text \
+            | jq -r '.SLACK_RUNBOOK_WEBHOOK_URL')
 
-          echo "$secrets" | python3 -c "
-          import json, sys
-          d = json.load(sys.stdin)
-          for k, v in d.items():
-              print(f'{k}={v}')
-          " >> $GITHUB_ENV
+          echo "SLACK_RUNBOOK_WEBHOOK_URL=$webhook_url" >> $GITHUB_ENV
 
       - name: Send Slack alert
         run: |
@@ -48,9 +46,9 @@ jobs:
               print("Error: SLACK_RUNBOOK_WEBHOOK_URL is not set", file=sys.stderr)
               sys.exit(1)
 
-          pr_title   = os.environ["PR_TITLE"]
-          pr_url     = os.environ["PR_URL"]
-          pr_author  = os.environ["PR_AUTHOR"]
+          pr_title  = os.environ.get("PR_TITLE", "(no title)")
+          pr_url    = os.environ.get("PR_URL", "")
+          pr_author = os.environ.get("PR_AUTHOR", "(unknown)")
 
           payload = {
               "blocks": [
@@ -75,7 +73,9 @@ jobs:
               with request.urlopen(req) as resp:
                   status = resp.read().decode("utf-8")
                   if status != "ok":
-                      print(f"Warning: Slack returned: {status!r}", file=sys.stderr)
+                      # Slack incoming webhooks return "ok" on success
+                      print(f"Slack error response: {status!r}", file=sys.stderr)
+                      sys.exit(1)
                   else:
                       print("Slack notification sent", file=sys.stderr)
           except urllib_error.HTTPError as e:

--- a/.github/workflows/bundle-request-alert.yml
+++ b/.github/workflows/bundle-request-alert.yml
@@ -1,0 +1,91 @@
+name: bundle-request-alert
+
+on:
+  pull_request:
+    types: [opened, labeled]
+    branches: [main]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    environment: bundle-runbook-env
+    permissions:
+      id-token: write
+      contents: read
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'bundle request') ||
+      (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'bundle request'))
+
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Load secrets from AWS Secrets Manager
+        run: |
+          secrets=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ vars.AWS_SECRET_ARN }}" \
+            --query SecretString \
+            --output text)
+
+          echo "$secrets" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          for k, v in d.items():
+              print(f'{k}={v}')
+          " >> $GITHUB_ENV
+
+      - name: Send Slack alert
+        run: |
+          python3 - <<'EOF'
+          import json, os, sys
+          from urllib import request, error as urllib_error
+
+          webhook_url = os.environ.get("SLACK_RUNBOOK_WEBHOOK_URL", "")
+          if not webhook_url:
+              print("Error: SLACK_RUNBOOK_WEBHOOK_URL is not set", file=sys.stderr)
+              sys.exit(1)
+
+          pr_title   = os.environ["PR_TITLE"]
+          pr_url     = os.environ["PR_URL"]
+          pr_author  = os.environ["PR_AUTHOR"]
+
+          payload = {
+              "blocks": [
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": (
+                              f":inbox_tray: *Bundle Request PR*\n"
+                              f"*<{pr_url}|{pr_title}>*\n"
+                              f"Submitted by: *{pr_author}*"
+                          ),
+                      },
+                  }
+              ]
+          }
+
+          data = json.dumps(payload).encode("utf-8")
+          req = request.Request(webhook_url, data=data, method="POST",
+                                headers={"Content-Type": "application/json"})
+          try:
+              with request.urlopen(req) as resp:
+                  status = resp.read().decode("utf-8")
+                  if status != "ok":
+                      print(f"Warning: Slack returned: {status!r}", file=sys.stderr)
+                  else:
+                      print("Slack notification sent", file=sys.stderr)
+          except urllib_error.HTTPError as e:
+              print(f"Slack API error {e.code}: {e.read().decode()}", file=sys.stderr)
+              sys.exit(1)
+          except urllib_error.URLError as e:
+              print(f"Network error: {e.reason}", file=sys.stderr)
+              sys.exit(1)
+          EOF
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Changes

- `.github/workflows/bundle-request-alert.yml` — new workflow that sends a Slack alert to `#solutions-bundles-alerts` when a PR targeting `main` is opened or labeled with \"bundle request\"
- `.github/workflows/README.md` — documents the new workflow

## Details

Uses the existing `bundle-runbook-env` environment and AWS OIDC + Secrets Manager infrastructure — no new secrets required. The webhook URL (`SLACK_RUNBOOK_WEBHOOK_URL`) is extracted with `jq` to avoid bulk env var injection. Trigger logic covers two cases:
- `labeled`: fires only when the \"bundle request\" label is the one being added
- `opened`: fires when a PR is created with the label pre-applied

## Testing

Verify by opening a PR against `main` and adding the \"bundle request\" label — a message should appear in `#solutions-bundles-alerts` with the PR title, author, and link.