### PR TITLE
fix(bundle-request-alert): correct Slack webhook retrieval from AWS Secrets Manager

### DIFF
--- a/.github/workflows/bundle-request-alert.yml
+++ b/.github/workflows/bundle-request-alert.yml
@@ -32,14 +32,17 @@ jobs:
             --query SecretString \
             --output text)
 
-          webhook_url=$(echo "$secrets" | python3 -c "import json,sys; print(json.load(sys.stdin)['SLACK_WEBHOOK_URL'])")
+          webhook_url=$(echo "$secrets" | python3 -c "import json,sys; print(json.load(sys.stdin).get('SLACK_WEBHOOK_URL', ''))")
 
           if [ -z "$webhook_url" ] || [ "$webhook_url" = "null" ]; then
             echo "Error: SLACK_WEBHOOK_URL key not found in secret ${{ vars.AWS_SECRET_ARN }}" >&2
             exit 1
           fi
 
-          echo "SLACK_WEBHOOK_URL=$webhook_url" >> $GITHUB_ENV
+          EOF=$(openssl rand -hex 8)
+          echo "SLACK_WEBHOOK_URL<<$EOF" >> "$GITHUB_ENV"
+          echo "$webhook_url"            >> "$GITHUB_ENV"
+          echo "$EOF"                    >> "$GITHUB_ENV"
 
       - name: Send Slack alert
         run: |
@@ -49,7 +52,7 @@ jobs:
 
           webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
           if not webhook_url:
-              print("Error: SLACK_RUNBOOK_WEBHOOK_URL is not set", file=sys.stderr)
+              print("Error: SLACK_WEBHOOK_URL is not set", file=sys.stderr)
               sys.exit(1)
 
           pr_title  = os.environ.get("PR_TITLE", "(no title)")

--- a/.github/workflows/bundle-request-alert.yml
+++ b/.github/workflows/bundle-request-alert.yml
@@ -25,15 +25,21 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Load Slack webhook from AWS Secrets Manager
+      - name: Load secrets from AWS Secrets Manager
         run: |
-          webhook_url=$(aws secretsmanager get-secret-value \
+          secrets=$(aws secretsmanager get-secret-value \
             --secret-id "${{ vars.AWS_SECRET_ARN }}" \
             --query SecretString \
-            --output text \
-            | jq -r '.SLACK_RUNBOOK_WEBHOOK_URL')
+            --output text)
 
-          echo "SLACK_RUNBOOK_WEBHOOK_URL=$webhook_url" >> $GITHUB_ENV
+          webhook_url=$(echo "$secrets" | python3 -c "import json,sys; print(json.load(sys.stdin)['SLACK_WEBHOOK_URL'])")
+
+          if [ -z "$webhook_url" ] || [ "$webhook_url" = "null" ]; then
+            echo "Error: SLACK_WEBHOOK_URL key not found in secret ${{ vars.AWS_SECRET_ARN }}" >&2
+            exit 1
+          fi
+
+          echo "SLACK_WEBHOOK_URL=$webhook_url" >> $GITHUB_ENV
 
       - name: Send Slack alert
         run: |
@@ -41,7 +47,7 @@ jobs:
           import json, os, sys
           from urllib import request, error as urllib_error
 
-          webhook_url = os.environ.get("SLACK_RUNBOOK_WEBHOOK_URL", "")
+          webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
           if not webhook_url:
               print("Error: SLACK_RUNBOOK_WEBHOOK_URL is not set", file=sys.stderr)
               sys.exit(1)


### PR DESCRIPTION
## Changes

- `.github/workflows/bundle-request-alert.yml` — fixes the `notify-slack` job which was failing with `ValueError: unknown url type: 'null'`

**Root cause:** The jq key `.SLACK_RUNBOOK_WEBHOOK_URL` did not exist in the secret JSON. When jq can't find a key it returns the string `"null"`, which passed Python's `if not webhook_url` guard and was handed to `urllib` as a URL.

**Fixes applied:**
- Replace jq extraction with Python `.get('SLACK_WEBHOOK_URL', '')` — matches the pattern used in `publish-runbook.yml` and handles missing keys gracefully
- Use GitHub's heredoc delimiter syntax for `$GITHUB_ENV` to prevent env var injection via embedded newlines in the secret value
- Fix stale error message (`SLACK_RUNBOOK_WEBHOOK_URL` → `SLACK_WEBHOOK_URL`) so diagnostics are accurate if the guard fires

🤖 Generated with [Claude Code](https://claude.ai/claude-code)