### PR TITLE
LOTC-1412: fix stale timestamp shift for renamed JSON keys

### DIFF
--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -256,6 +256,26 @@ def _extract_sample_data(data, tinfo, config, state):
 _FORMAT_DIVISORS = {"s": 1, "ms": 1_000, "us": 1_000_000, "ns": 1_000_000_000}
 
 
+def _resolve_sample_key(col, sample_data):
+    """Resolve the actual key in sample_data for an output column.
+
+    The output column name (e.g. "timestamp") may differ from the raw JSON
+    input key (e.g. "reqTimeSec").  Check the output name first, then fall
+    back to from_json_pointers in the column source.
+    """
+    col_name = col["name"]
+    if col_name in sample_data:
+        return col_name
+
+    source = col.get("datatype", {}).get("source") or {}
+    for ptr in source.get("from_json_pointers", []):
+        key = ptr.lstrip("/")
+        if key in sample_data:
+            return key
+
+    return None
+
+
 def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
     """Shift stale epoch timestamps in sample_data to the 1st of the current month.
 
@@ -268,19 +288,22 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
         return
 
     # Find the primary epoch column and build a map of epoch column formats
-    primary_col_name = None
+    # Resolve each column's actual key in sample_data (may differ from output name)
+    primary_col = None
     primary_format = "s"
-    epoch_col_formats = {}  # col_name -> format string
+    epoch_columns = []  # list of (sample_key, format)
     for col in output_columns:
         dt = col.get("datatype", {})
         if dt.get("type") == "epoch":
             col_format = dt.get("format", "s")
-            epoch_col_formats[col["name"]] = col_format
+            sample_key = _resolve_sample_key(col, sample_data)
+            if sample_key:
+                epoch_columns.append((sample_key, col_format))
             if dt.get("primary"):
-                primary_col_name = col["name"]
+                primary_col = (sample_key, col_format)
                 primary_format = col_format
 
-    if not primary_col_name:
+    if not primary_col or not primary_col[0]:
         if config.verbose:
             print(
                 f"[Transform Org] No primary epoch column found in "
@@ -289,11 +312,12 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
             )
         return
 
-    primary_value = sample_data.get(primary_col_name)
+    primary_key = primary_col[0]
+    primary_value = sample_data.get(primary_key)
     if not isinstance(primary_value, (int, float)):
         if config.verbose:
             print(
-                f"[Transform Org] Primary timestamp '{primary_col_name}' is not numeric "
+                f"[Transform Org] Primary timestamp '{primary_key}' is not numeric "
                 f"in sample_data for {os.path.basename(tinfo.final_path)}, skipping shift",
                 file=sys.stderr,
             )
@@ -318,12 +342,12 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
     delta_secs = target_epoch - primary_secs
 
     shifted_fields = []
-    for col_name, col_format in epoch_col_formats.items():
-        if col_name in sample_data and isinstance(sample_data[col_name], (int, float)):
+    for sample_key, col_format in epoch_columns:
+        if isinstance(sample_data.get(sample_key), (int, float)):
             col_divisor = _FORMAT_DIVISORS.get(col_format, 1)
             col_delta = delta_secs * col_divisor
-            sample_data[col_name] = int(sample_data[col_name]) + col_delta
-            shifted_fields.append(col_name)
+            sample_data[sample_key] = int(sample_data[sample_key]) + col_delta
+            shifted_fields.append(sample_key)
 
     if config.verbose and shifted_fields:
         print(

--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -261,17 +261,26 @@ def _resolve_sample_key(col, sample_data):
 
     The output column name (e.g. "timestamp") may differ from the raw JSON
     input key (e.g. "reqTimeSec").  Check the output name first, then fall
-    back to from_json_pointers in the column source.
+    back to single-segment from_json_pointers in the column source.
+
+    Only single-segment pointers (e.g. "/reqTimeSec") are resolved — nested
+    pointers (e.g. "/avail/fillRate") cannot be mapped to a flat sample_data
+    key and are skipped.
     """
-    col_name = col["name"]
+    col_name = col.get("name")
+    if not col_name:
+        return None
     if col_name in sample_data:
         return col_name
 
     source = col.get("datatype", {}).get("source") or {}
     for ptr in source.get("from_json_pointers", []):
-        key = ptr.lstrip("/")
-        if key in sample_data:
-            return key
+        # Only resolve single-segment JSON pointers (e.g. "/reqTimeSec")
+        segments = ptr.strip("/").split("/")
+        if len(segments) == 1 and segments[0]:
+            key = segments[0]
+            if key in sample_data:
+                return key
 
     return None
 

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -29,6 +29,7 @@ sys.modules.setdefault("utils.file_utils", _utils_pkg.file_utils)
 from scripts.configurator.transform_organizer import (
     _shift_stale_timestamps,
     _extract_sample_data,
+    _resolve_sample_key,
     _STALENESS_THRESHOLD_SECS,
 )
 from scripts.configurator.config import BundleConfig, BundleState, TransformInfo
@@ -405,3 +406,156 @@ class TestExtractSampleDataIntegration:
         assert ok is True
         sample = transform_data["settings"]["sample_data"]
         assert sample["timestamp"] == fresh_ts
+
+
+# ---------------------------------------------------------------------------
+# Tests for _resolve_sample_key (LOTC-1412)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSampleKey:
+    """Tests for JSON pointer resolution when output name != raw key."""
+
+    def test_output_name_matches_sample_key(self):
+        """When output name exists in sample_data, return it directly."""
+        col = {"name": "timestamp", "datatype": {"type": "epoch", "source": None}}
+        sample = {"timestamp": 1700000000}
+        assert _resolve_sample_key(col, sample) == "timestamp"
+
+    def test_json_pointer_fallback(self):
+        """When output name is missing, resolve from from_json_pointers."""
+        col = {
+            "name": "timestamp",
+            "datatype": {
+                "type": "epoch",
+                "source": {"from_json_pointers": ["/reqTimeSec"]},
+            },
+        }
+        sample = {"reqTimeSec": 1700000000}
+        assert _resolve_sample_key(col, sample) == "reqTimeSec"
+
+    def test_no_match_returns_none(self):
+        """When neither output name nor pointer matches, return None."""
+        col = {
+            "name": "timestamp",
+            "datatype": {
+                "type": "epoch",
+                "source": {"from_json_pointers": ["/missing_field"]},
+            },
+        }
+        sample = {"reqTimeSec": 1700000000}
+        assert _resolve_sample_key(col, sample) is None
+
+    def test_no_source_returns_none(self):
+        """When column has no source (e.g. sql_transform derived), return None if name missing."""
+        col = {
+            "name": "computed_ts",
+            "datatype": {"type": "epoch", "source": {"from_input_field": "sql_transform"}},
+        }
+        sample = {"reqTimeSec": 1700000000}
+        assert _resolve_sample_key(col, sample) is None
+
+    def test_output_name_preferred_over_pointer(self):
+        """If output name exists in sample, use it even if pointer also matches."""
+        col = {
+            "name": "timestamp",
+            "datatype": {
+                "type": "epoch",
+                "source": {"from_json_pointers": ["/reqTimeSec"]},
+            },
+        }
+        sample = {"timestamp": 1700000000, "reqTimeSec": 1699999999}
+        assert _resolve_sample_key(col, sample) == "timestamp"
+
+
+# ---------------------------------------------------------------------------
+# Tests for shifted timestamps with JSON pointer resolution (LOTC-1412)
+# ---------------------------------------------------------------------------
+
+
+class TestShiftWithJsonPointer:
+    """End-to-end shift tests where output column name != raw JSON key."""
+
+    def test_akamai_style_reqtimesec_shifted(self, tmp_path):
+        """Akamai-style transform: output 'timestamp' from raw 'reqTimeSec'."""
+        stale_ts = _now_epoch() - (365 * 86400)
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "epoch",
+                            "primary": True,
+                            "format": "s",
+                            "source": {"from_json_pointers": ["/reqTimeSec"]},
+                        },
+                    },
+                    {"name": "bytes", "datatype": {"type": "uint64"}},
+                ],
+                "sample_data": {"reqTimeSec": stale_ts, "bytes": 4096},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        expected_target = _first_of_month_epoch()
+        assert sample["reqTimeSec"] == expected_target
+        assert sample["bytes"] == 4096
+
+    def test_fresh_akamai_style_not_shifted(self, tmp_path):
+        """Fresh Akamai-style timestamps should not be shifted."""
+        fresh_ts = _now_epoch() - (30 * 86400)
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "epoch",
+                            "primary": True,
+                            "format": "s",
+                            "source": {"from_json_pointers": ["/reqTimeSec"]},
+                        },
+                    },
+                ],
+                "sample_data": {"reqTimeSec": fresh_ts},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["reqTimeSec"] == fresh_ts
+
+    def test_unresolvable_primary_skips(self, tmp_path):
+        """If primary epoch column can't be resolved to a sample key, skip."""
+        stale_ts = _now_epoch() - (365 * 86400)
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "epoch",
+                            "primary": True,
+                            "format": "s",
+                            "source": {"from_input_field": "sql_transform"},
+                        },
+                    },
+                ],
+                "sample_data": {"some_other_field": stale_ts},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path, verbose=True)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["some_other_field"] == stale_ts

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -283,17 +283,23 @@ class TestShiftStaleTimestamps:
     def test_threshold_boundary_plus_one_shifted(self, tmp_path):
         """Data 1 second past the threshold should be shifted."""
         fixed_now = 1800000000
+        # 2027-01-15 approx — target should be 2027-01-01 00:00 UTC = 1798761600
+        fixed_target = 1798761600
         stale_ts = fixed_now - _STALENESS_THRESHOLD_SECS - 1
         data = _make_transform_data(stale_ts)
         sample = data["settings"]["sample_data"]
         config = _make_config(tmp_path)
         tinfo = _make_tinfo(tmp_path)
 
-        with patch("scripts.configurator.transform_organizer.time") as mock_time:
+        fixed_dt = datetime(2027, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        with patch("scripts.configurator.transform_organizer.time") as mock_time, \
+             patch("scripts.configurator.transform_organizer.datetime") as mock_dt:
             mock_time.time.return_value = fixed_now
+            mock_dt.now.return_value = fixed_dt
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
             _shift_stale_timestamps(sample, data, tinfo, config)
 
-        assert sample["timestamp"] == _first_of_month_epoch()
+        assert sample["timestamp"] == fixed_target
 
     def test_millisecond_format_shifted_correctly(self, tmp_path):
         """Epoch-ms timestamps should be normalized to seconds for comparison and shifted in ms."""
@@ -446,13 +452,31 @@ class TestResolveSampleKey:
         sample = {"reqTimeSec": 1700000000}
         assert _resolve_sample_key(col, sample) is None
 
-    def test_no_source_returns_none(self):
-        """When column has no source (e.g. sql_transform derived), return None if name missing."""
+    def test_source_without_json_pointers_returns_none(self):
+        """When source has from_input_field but no from_json_pointers, return None."""
         col = {
             "name": "computed_ts",
             "datatype": {"type": "epoch", "source": {"from_input_field": "sql_transform"}},
         }
         sample = {"reqTimeSec": 1700000000}
+        assert _resolve_sample_key(col, sample) is None
+
+    def test_nested_pointer_skipped(self):
+        """Multi-segment JSON pointers (e.g. /avail/fillRate) cannot be resolved to flat keys."""
+        col = {
+            "name": "fill_rate",
+            "datatype": {
+                "type": "epoch",
+                "source": {"from_json_pointers": ["/avail/fillRate"]},
+            },
+        }
+        sample = {"avail/fillRate": 1700000000}  # even if flat key exists, nested pointer skipped
+        assert _resolve_sample_key(col, sample) is None
+
+    def test_missing_name_returns_none(self):
+        """Column without a name field returns None gracefully."""
+        col = {"datatype": {"type": "epoch"}}
+        sample = {"timestamp": 1700000000}
         assert _resolve_sample_key(col, sample) is None
 
     def test_output_name_preferred_over_pointer(self):


### PR DESCRIPTION
## Summary
- Fix `_shift_stale_timestamps()` in `transform_organizer.py` to resolve `from_json_pointers` when the output column name differs from the raw sample_data key (e.g. `timestamp` vs `reqTimeSec`)
- Add `_resolve_sample_key()` helper that tries the output name first, then falls back to single-segment JSON pointers
- Guard against nested pointers (e.g. `/avail/fillRate`) that can't map to flat sample_data keys

## Changes
- `scripts/configurator/transform_organizer.py` — new `_resolve_sample_key()` helper, refactored `_shift_stale_timestamps()` to use resolved keys
- `tests/test_timestamp_freshness.py` — 10 new tests covering JSON pointer resolution, nested pointer skip, missing name, Akamai-style transforms, and deterministic boundary tests

## Test plan
- [x] All 24 tests pass (`python3 -m pytest tests/test_timestamp_freshness.py -v`)
- [ ] Re-run bot-insights-cdn bundle through pipeline to verify timestamps get freshened automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)