### PR TITLE
fix: handle wrapped dashboards and inject inputs in portables converter

### DIFF
--- a/scripts/converters/discoverer.py
+++ b/scripts/converters/discoverer.py
@@ -150,15 +150,31 @@ class AssetDiscoverer:
             try:
                 dashboard_data = read_json(json_file)
 
-                # Extract __inputs array
+                # Unwrap {"dashboard": {...}} bundle format if present
+                source_data = dashboard_data
+                if (isinstance(dashboard_data, dict)
+                        and list(dashboard_data.keys()) == ['dashboard']
+                        and isinstance(dashboard_data.get('dashboard'), dict)):
+                    source_data = dashboard_data['dashboard']
+
+                # Extract __inputs array; fall back to templating.list constants
                 inputs = []
-                if '__inputs' in dashboard_data:
-                    for inp in dashboard_data['__inputs']:
+                if '__inputs' in source_data:
+                    for inp in source_data['__inputs']:
                         inputs.append(DashboardInput(
                             name=inp.get('name', ''),
                             type=inp.get('type', ''),
                             value=inp.get('value')
                         ))
+                else:
+                    # Derive inputs from constant template variables
+                    for var in source_data.get('templating', {}).get('list', []):
+                        if var.get('type') == 'constant' and var.get('name'):
+                            inputs.append(DashboardInput(
+                                name=var['name'],
+                                type='constant',
+                                value=var.get('query', '')
+                            ))
 
                 # Determine relative path and folder
                 rel_path = json_file.relative_to(folder)

--- a/scripts/converters/grafana_gen.py
+++ b/scripts/converters/grafana_gen.py
@@ -69,13 +69,47 @@ class GrafanaGenerator:
             # Read, replace datasource UIDs, write cleaned JSON
             with open(dashboard.file_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
+
+            # Unwrap {"dashboard": {...}} bundle format if present
+            if isinstance(data, dict) and list(data.keys()) == ['dashboard'] and isinstance(data.get('dashboard'), dict):
+                data = data['dashboard']
+
             self._replace_datasource_uids(data)
 
-            # Normalize __inputs datasource names to standard variable
-            for inp in data.get('__inputs', []):
-                if inp.get('type') == 'datasource':
-                    inp['name'] = 'DS_HYDROLIX-HYDROLIX-DATASOURCE'
-                    inp['label'] = 'Hydrolix'
+            # Ensure __inputs contains a datasource entry
+            inputs = data.get('__inputs', [])
+            has_ds_input = any(inp.get('type') == 'datasource' for inp in inputs)
+            if has_ds_input:
+                # Normalize existing datasource input name to standard variable
+                for inp in inputs:
+                    if inp.get('type') == 'datasource':
+                        inp['name'] = 'DS_HYDROLIX-HYDROLIX-DATASOURCE'
+                        inp['label'] = 'Hydrolix'
+            else:
+                # Inject datasource input required by the portables validator
+                inputs.insert(0, {
+                    'name': 'DS_HYDROLIX-HYDROLIX-DATASOURCE',
+                    'label': 'Hydrolix',
+                    'description': '',
+                    'type': 'datasource',
+                    'pluginId': 'hydrolix-hydrolix-datasource',
+                    'pluginName': 'Hydrolix',
+                })
+
+            # Add constant template variables as inputs if not already present
+            existing_names = {inp.get('name') for inp in inputs}
+            for var in data.get('templating', {}).get('list', []):
+                if var.get('type') == 'constant' and var.get('name') and var['name'] not in existing_names:
+                    inputs.append({
+                        'name': var['name'],
+                        'type': 'constant',
+                        'label': var.get('label') or var['name'],
+                        'value': var.get('query', ''),
+                        'description': '',
+                    })
+                    existing_names.add(var['name'])
+
+            data['__inputs'] = inputs
 
             # Strip top-level dashboard uid (CaC deployments assign their own)
             data.pop('uid', None)
@@ -169,19 +203,12 @@ class GrafanaGenerator:
                 'folderUid': deepest_folder_uid
             }
 
-            # Add inputs if present - as a flat dict
-            if dashboard.inputs:
-                inputs_dict = {}
-                for inp in dashboard.inputs:
-                    # Use the input name as the key, and value/type as the value
-                    # For datasource inputs, use the predefined datasource UID
-                    if inp.type == 'datasource':
-                        inputs_dict['DS_HYDROLIX-HYDROLIX-DATASOURCE'] = 'hdx-hydrolix-datasource'
-                    elif inp.value is not None:
-                        inputs_dict[inp.name] = inp.value
-                    else:
-                        inputs_dict[inp.name] = ''
-                dashboard_entry['inputs'] = inputs_dict
+            # Build inputs dict — always include datasource, plus any constant inputs
+            inputs_dict = {'DS_HYDROLIX-HYDROLIX-DATASOURCE': 'hdx-hydrolix-datasource'}
+            for inp in dashboard.inputs:
+                if inp.type != 'datasource':
+                    inputs_dict[inp.name] = inp.value if inp.value is not None else ''
+            dashboard_entry['inputs'] = inputs_dict
 
             # Mark as home dashboard if specified
             if home_dashboard and dashboard.filename == home_dashboard:


### PR DESCRIPTION
## Summary

- **`grafana_gen.py`**: Unwraps `{"dashboard": {...}}` bundle format before processing dashboards, injects the required datasource entry into `__inputs` when missing, adds constant template variables from `templating.list` as `__inputs`, and always includes the datasource in `resources.gfo.yaml` inputs
- **`discoverer.py`**: Unwraps `{"dashboard": {...}}` format when reading source dashboards, falls back to extracting constant variables from `templating.list` as inputs when `__inputs` is absent

## Context

Bundle-format dashboards use a `{"dashboard": {...}}` wrapper and store table/datasource references as plain constant variables (e.g. `raw_table = "__PROJECT_NAME__.__TABLE_NAME__"`) rather than Grafana `__inputs`. The portables converter previously produced output dashboards with no `__inputs` beyond the datasource, and `resources.gfo.yaml` with no `inputs` entries — both required for CaC deployment.

## Test plan

- [ ] Run `python3 scripts/bundle_to_yaml.py --source aws/cdn-insights --verbose` and confirm all 4 phases pass
- [ ] Verify generated dashboard JSONs contain `__inputs` with datasource + all constant template variables
- [ ] Verify `resources.gfo.yaml` contains an `inputs` map for each dashboard
- [ ] Confirm `trafficpeak/security` still converts correctly (dashboards already have `__inputs` — existing path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)