### PR TITLE
LOTC-1420: add --delay flag

### DIFF
--- a/src/deploy/default.rs
+++ b/src/deploy/default.rs
@@ -10,9 +10,13 @@ use crate::models::output::Output;
 use crate::models::output::OutputTable;
 use crate::models::output::OutputTransformation;
 use crate::BUNDLE_TESTING_CLUSTER;
+use crate::DELAY_MODE;
 use crate::GRAFANA_LOCATION;
 
 const TABLE_READY_DELAY_SECS: u64 = 30;
+const TABLE_PROPAGATION_DELAY_SECS: u64 = 15;
+const TABLE_PROPAGATION_DELAY_SLOW_SECS: u64 = 45;
+const TRANSFORM_READY_DELAY_SECS: u64 = 15;
 const DATA_READY_DELAY_SECS: u64 = 30;
 
 pub async fn run(base: &str, bundle: &Bundle, output: &mut Output) -> Result<Vec<String>, String> {
@@ -72,8 +76,14 @@ pub async fn run(base: &str, bundle: &Bundle, output: &mut Output) -> Result<Vec
 
     // Wait for tables to propagate to ClickHouse before creating summary tables
     if bundle.summary_tables.is_some() && !bundle.tables.is_empty() {
-        println!("Waiting for tables to propagate to ClickHouse...");
-        tokio::time::sleep(tokio::time::Duration::from_secs(15)).await;
+        let propagation_secs = if *DELAY_MODE {
+            println!("Waiting for tables to propagate to ClickHouse (--delay)...");
+            TABLE_PROPAGATION_DELAY_SLOW_SECS
+        } else {
+            println!("Waiting for tables to propagate to ClickHouse...");
+            TABLE_PROPAGATION_DELAY_SECS
+        };
+        sleep(Duration::from_secs(propagation_secs)).await;
     }
 
     // Create summary tables if present (will actively verify parent tables exist)
@@ -182,6 +192,11 @@ async fn process_table(
             Ok(v) => v,
             Err(e) => return Err(e),
         };
+
+        if *DELAY_MODE {
+            println!("Waiting for transform to propagate (--delay)...");
+            sleep(Duration::from_secs(TRANSFORM_READY_DELAY_SECS)).await;
+        }
 
         match insert_sample_data_if_present(
             bearer_token,

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -8,6 +8,7 @@ pub struct Flags {
     pub dump_output: bool,
     pub strict_plugins: bool,
     pub production_mode: bool,
+    pub delay_mode: bool,
     pub use_guid: bool,
     pub cleanup_project: Option<String>,
     pub match_only: String,
@@ -25,6 +26,7 @@ impl Flags {
             dump_output: false,
             strict_plugins: false,
             production_mode: false,
+            delay_mode: false,
             use_guid: false,
             cleanup_project: None,
             match_only: String::new(),
@@ -40,6 +42,7 @@ impl Flags {
                 "--output" => flags.dump_output = true,
                 "--strict-plugins" => flags.strict_plugins = true,
                 "--production" => flags.production_mode = true,
+                "--delay" => flags.delay_mode = true,
                 "--guid" => flags.use_guid = true,
                 "--cleanup" => {
                     i += 1;
@@ -72,6 +75,11 @@ impl Flags {
         // Validate: --guid requires --local
         if flags.use_guid && !flags.is_local {
             return Err("--guid can only be used with --local".to_string());
+        }
+
+        // Validate: --delay requires --local
+        if flags.delay_mode && !flags.is_local {
+            return Err("--delay can only be used with --local".to_string());
         }
 
         Ok(flags)
@@ -136,9 +144,29 @@ mod tests {
     }
 
     #[test]
+    fn test_delay_requires_local() {
+        let result = Flags::parse(&args(&["--delay"]));
+        assert!(result.is_err(), "--delay without --local should fail");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("--local"),
+            "Error should mention --local, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_delay_with_local_succeeds() {
+        let flags = Flags::parse(&args(&["--local", "--delay"])).unwrap();
+        assert!(flags.delay_mode);
+        assert!(flags.is_local);
+    }
+
+    #[test]
     fn test_default_flags() {
         let flags = Flags::parse(&args(&[])).unwrap();
         assert!(!flags.use_guid);
+        assert!(!flags.delay_mode);
         assert!(!flags.is_local);
         assert!(flags.cleanup_project.is_none());
         assert!(flags.match_only.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ lazy_static! {
         let args: Vec<String> = std::env::args().collect();
         args.contains(&"--production".to_string())
     };
+    static ref DELAY_MODE: bool = {
+        let args: Vec<String> = std::env::args().collect();
+        args.contains(&"--delay".to_string())
+    };
     static ref MATCH_ONLY: String = {
         let mut value = "".to_string();
         let args: Vec<String> = std::env::args().collect();


### PR DESCRIPTION
## Summary

Adds a `--delay` CLI flag to the Rust bundle validator for clusters with slower propagation times.

- `cargo run -- --local --delay trafficpeak_siem`
- Without `--delay`: default timing unchanged (15s table propagation, no transform wait)
- With `--delay`: 45s table propagation + 15s transform propagation wait

Requires `--local` — errors if used alone.

## Changes

- **`src/main.rs`** — add `DELAY_MODE` to `lazy_static!` flags
- **`src/flags.rs`** — add `delay_mode` field, `--delay` parsing, `--delay` requires `--local` validation, 2 new tests
- **`src/deploy/default.rs`** — conditional delays gated on `DELAY_MODE` with named constants

## Test plan

- [x] `cargo test` — all 44 tests pass (including new delay flag tests)
- [x] `cargo build` — compiles clean
- [x] Pre-commit hooks pass (rustfmt, clippy, cargo check)
- [ ] Manual: `cargo run -- --delay` should error with "--delay can only be used with --local"
- [ ] Manual: `cargo run -- --local --delay <bundle>` should show "(--delay)" in propagation log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)