### PR TITLE
LOTC-1437: retry validator insert on 'unknown transform' 400

### DIFF
--- a/src/hdx/table.rs
+++ b/src/hdx/table.rs
@@ -424,15 +424,7 @@ pub async fn insert_into(
         let status = response.status();
         let error_body = response.text().await.unwrap_or_default();
 
-        // Check if this is a retryable error
-        let is_retryable = match status.as_u16() {
-            // Client errors that shouldn't be retried
-            400..=499 if status != 408 && status != 429 => false,
-            // Server errors and rate limiting - retryable
-            500..=599 | 408 | 429 => true,
-            // Other status codes - retryable
-            _ => true,
-        };
+        let is_retryable = is_insert_retryable(status.as_u16(), &error_body);
 
         eprintln!(
             "Hydrolix insert failed on attempt {}/{}, status: {} (retryable: {}) url={url} {}.{}",
@@ -695,4 +687,49 @@ pub async fn create_summary(
         ));
     }
     Ok(table_name.to_string())
+}
+
+fn is_insert_retryable(status: u16, error_body: &str) -> bool {
+    // "unknown transform" is eventual-consistency lag after transform creation,
+    // not a real 4xx — retry with backoff until the ingest endpoint sees it.
+    if status == 400 && error_body.contains("unknown transform") {
+        return true;
+    }
+    match status {
+        400..=499 if status != 408 && status != 429 => false,
+        500..=599 | 408 | 429 => true,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_transform_400_is_retryable() {
+        let body = r#"{"code":400,"message":"unknown transform 'akamai'"}"#;
+        assert!(is_insert_retryable(400, body));
+    }
+
+    #[test]
+    fn other_400_is_not_retryable() {
+        assert!(!is_insert_retryable(
+            400,
+            r#"{"code":400,"message":"bad input"}"#
+        ));
+        assert!(!is_insert_retryable(404, "not found"));
+    }
+
+    #[test]
+    fn rate_limit_and_timeout_are_retryable() {
+        assert!(is_insert_retryable(408, ""));
+        assert!(is_insert_retryable(429, "rate limited"));
+    }
+
+    #[test]
+    fn server_errors_are_retryable() {
+        assert!(is_insert_retryable(500, ""));
+        assert!(is_insert_retryable(503, ""));
+    }
 }


### PR DESCRIPTION
## Summary
- Narrowly treats `400 Bad Request` with body containing `"unknown transform"` as retryable in `src/hdx/table.rs::insert_into`.
- Existing exponential backoff (1s → 60s cap, 20 attempts) now handles transform propagation lag on the Hydrolix ingest endpoint.
- Extracts `is_retryable` classification into a pure `is_insert_retryable(status, body)` helper so it's unit-testable.
- Adds 4 unit tests covering the retryable/non-retryable cases.

## Why
After a transform is created on the control plane, the ingest endpoint can briefly return `400 {"code":400,"message":"unknown transform '<name>'"}` until propagation catches up. This is eventual-consistency lag, not a real client error, but today the validator classifies all 4xx as non-retryable and hard-fails on attempt 1.

Complementary to LOTC-1420's `--delay` flag (static pre-insert wait) — this change is reactive and adaptive: zero cost when the first attempt succeeds, automatically handles arbitrarily long propagation windows within the existing retry budget.

Discovered while validating `trafficpeak/bot-insights-cdn` (LOTC-646) against `demo.aws.hydrolix.live`.

## Test plan
- [x] `cargo test --lib hdx::table` — 4 passing unit tests
- [x] `cargo fmt` / `cargo clippy` / `cargo check` — pre-commit hooks passed
- [ ] Manual `cargo run -- --local bot_insights_cdn` to confirm the retry path succeeds where the first attempt previously failed

## Links
- Jira: https://hydrolix.atlassian.net/browse/LOTC-1437
- Related: LOTC-1420 (`--delay` flag), LOTC-646 (bundle where discovered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)