### PR TITLE
LOTC-1439: fix _shift_stale_timestamps for quoted epoch strings

### DIFF
--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -285,6 +285,21 @@ def _resolve_sample_key(col, sample_data):
     return None
 
 
+def _coerce_numeric_epoch(value):
+    """Return value coerced to int if it's a numeric-looking string, else unchanged.
+
+    Raw vendor exports sometimes serialize epochs as JSON strings (e.g.
+    "1607368207"). Callers still want to treat them as numbers for the
+    staleness check and delta math. Non-numeric values (including strings
+    like "not-a-number") pass through unchanged.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.lstrip("-").isdigit():
+            return int(stripped)
+    return value
+
+
 def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
     """Shift stale epoch timestamps in sample_data to the 1st of the current month.
 
@@ -322,7 +337,7 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
         return
 
     primary_key = primary_col[0]
-    primary_value = sample_data.get(primary_key)
+    primary_value = _coerce_numeric_epoch(sample_data.get(primary_key))
     if not isinstance(primary_value, (int, float)):
         if config.verbose:
             print(
@@ -352,10 +367,13 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
 
     shifted_fields = []
     for sample_key, col_format in epoch_columns:
-        if isinstance(sample_data.get(sample_key), (int, float)):
+        raw = sample_data.get(sample_key)
+        coerced = _coerce_numeric_epoch(raw)
+        if isinstance(coerced, (int, float)):
             col_divisor = _FORMAT_DIVISORS.get(col_format, 1)
             col_delta = delta_secs * col_divisor
-            sample_data[sample_key] = int(sample_data[sample_key]) + col_delta
+            shifted = int(coerced) + col_delta
+            sample_data[sample_key] = str(shifted) if isinstance(raw, str) else shifted
             shifted_fields.append(sample_key)
 
     if config.verbose and shifted_fields:

--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -295,7 +295,7 @@ def _coerce_numeric_epoch(value):
     """
     if isinstance(value, str):
         stripped = value.strip()
-        if stripped.lstrip("-").isdigit():
+        if stripped.removeprefix("-").isdigit():
             return int(stripped)
     return value
 

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -265,6 +265,64 @@ class TestShiftStaleTimestamps:
 
         assert sample["timestamp"] == "not-a-number"
 
+    def test_primary_stale_string_epoch_shifted(self, tmp_path):
+        """Quoted numeric epoch (e.g. '1607368207') must be shifted like a number.
+
+        Regression for LOTC-1439: raw vendor exports sometimes serialize epochs
+        as JSON strings. The shifter must recognize them and preserve the
+        string type on writeback so downstream tooling sees the same shape.
+        """
+        stale_ts_str = "1607368207"  # Dec 7, 2020 — well over 183 days stale
+        data = _make_transform_data(stale_ts_str)
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        expected_target = _first_of_month_epoch()
+        assert sample["timestamp"] == str(expected_target)
+        assert isinstance(sample["timestamp"], str)
+
+    def test_secondary_string_epoch_shifted_preserving_type(self, tmp_path):
+        """Secondary epoch column with a quoted numeric value is shifted and stays a string.
+
+        Mirrors the real edns case: multiple columns can carry quoted epochs,
+        and every one of them must move by the same delta. The type on the
+        way out should match the type on the way in.
+        """
+        stale_secs = _now_epoch() - (365 * 86400)
+        secondary_str = str(stale_secs - 3600)  # 1 hour before primary, as string
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {"type": "epoch", "primary": True, "format": "s"},
+                    },
+                    {
+                        "name": "ts_sec_idx",
+                        "datatype": {"type": "epoch", "format": "s"},
+                    },
+                ],
+                "sample_data": {
+                    "timestamp": stale_secs,  # numeric primary
+                    "ts_sec_idx": secondary_str,  # string secondary
+                },
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        target = _first_of_month_epoch()
+        delta = target - stale_secs
+        assert sample["timestamp"] == target
+        assert sample["ts_sec_idx"] == str(int(secondary_str) + delta)
+        assert isinstance(sample["ts_sec_idx"], str)
+
     def test_threshold_boundary_not_shifted(self, tmp_path):
         """Data exactly at the 183-day threshold should not be shifted."""
         fixed_now = 1800000000  # fixed reference time

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -245,7 +245,7 @@ class TestShiftStaleTimestamps:
         assert sample["timestamp"] == 1000000000
 
     def test_primary_value_not_numeric_skips(self, tmp_path):
-        """If primary timestamp value is a string, skip without error."""
+        """If primary timestamp is a non-numeric string, skip without error."""
         data = {
             "settings": {
                 "output_columns": [


### PR DESCRIPTION
## Summary
- Raw vendor exports sometimes serialize epoch timestamps as JSON strings (e.g. `"1607368207"`). The `isinstance(int, float)` guard in `_shift_stale_timestamps` silently skipped them, leaving stale `sample_data` that got aged out of test tables with `max_age_days: 1` — ingest returned 200 but count was 0.
- Add a `_coerce_numeric_epoch()` helper (single leading-minus aware, integer-only) applied at the primary staleness guard and the per-column shift loop. String inputs round-trip as strings to preserve JSON shape.
- Regression tests added in `tests/test_timestamp_freshness.py` covering the primary and secondary string-epoch paths.

## Changes
- `scripts/configurator/transform_organizer.py` — `_coerce_numeric_epoch()` helper; primary guard + per-column loop updated
- `tests/test_timestamp_freshness.py` — `test_primary_stale_string_epoch_shifted`, `test_secondary_string_epoch_shifted_preserving_type`; docstring of existing `test_primary_value_not_numeric_skips` clarified

## Test plan
- [x] `python3 -m pytest tests/test_timestamp_freshness.py` — 26 pass
- [x] `python3 -m pytest tests/` — full suite 104 pass
- [x] Verified on `trafficpeak/edns` bundle: pipeline output contains a recent timestamp (user-confirmed)

Fixes LOTC-1439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)