### PR TITLE
LOTC-1447: shift stale datetime primaries

### DIFF
--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -3,6 +3,7 @@
 import calendar
 import json
 import os
+import re
 import shutil
 import sys
 import time
@@ -13,6 +14,39 @@ from .constants import TRANSFORM_METADATA_FIELDS
 
 # 183 days in seconds (approximately 6 months)
 _STALENESS_THRESHOLD_SECS = 183 * 86400
+
+# Go reference time tokens -> strptime directives. Longer tokens first so that a
+# positional scan picks "2006" before "06", "15" before "5", etc.
+_GO_LAYOUT_TOKENS = (
+    ("2006", "%Y"),
+    ("01", "%m"),
+    ("02", "%d"),
+    ("15", "%H"),
+    ("04", "%M"),
+    ("05", "%S"),
+)
+
+
+def _translate_go_layout(fmt):
+    """Translate a Go reference-time layout to a strptime/strftime format string.
+
+    Scans positionally so tokens never match inside strptime directives we've
+    already emitted. Unknown characters pass through as literals.
+    """
+    out = []
+    i = 0
+    while i < len(fmt):
+        matched = False
+        for go_token, py_token in _GO_LAYOUT_TOKENS:
+            if fmt.startswith(go_token, i):
+                out.append(py_token)
+                i += len(go_token)
+                matched = True
+                break
+        if not matched:
+            out.append(fmt[i])
+            i += 1
+    return "".join(out)
 
 
 def run_transform_organization(config, state):
@@ -260,8 +294,11 @@ def _resolve_sample_key(col, sample_data):
     """Resolve the actual key in sample_data for an output column.
 
     The output column name (e.g. "timestamp") may differ from the raw JSON
-    input key (e.g. "reqTimeSec").  Check the output name first, then fall
-    back to single-segment from_json_pointers in the column source.
+    input key (e.g. "reqTimeSec" or "EdgeStartTimestamp"). Prefer the output
+    name if it is present with a non-null value; otherwise fall through to
+    single-segment from_json_pointers and then from_input_field. As a last
+    resort, return the output name even if its value is null so legacy
+    callers still see the key.
 
     Only single-segment pointers (e.g. "/reqTimeSec") are resolved — nested
     pointers (e.g. "/avail/fillRate") cannot be mapped to a flat sample_data
@@ -270,7 +307,7 @@ def _resolve_sample_key(col, sample_data):
     col_name = col.get("name")
     if not col_name:
         return None
-    if col_name in sample_data:
+    if col_name in sample_data and sample_data.get(col_name) is not None:
         return col_name
 
     source = col.get("datatype", {}).get("source") or {}
@@ -279,9 +316,19 @@ def _resolve_sample_key(col, sample_data):
         segments = ptr.strip("/").split("/")
         if len(segments) == 1 and segments[0]:
             key = segments[0]
-            if key in sample_data:
+            if key in sample_data and sample_data.get(key) is not None:
                 return key
 
+    from_input = source.get("from_input_field")
+    if (
+        isinstance(from_input, str)
+        and from_input in sample_data
+        and sample_data.get(from_input) is not None
+    ):
+        return from_input
+
+    if col_name in sample_data:
+        return col_name
     return None
 
 
@@ -298,6 +345,59 @@ def _coerce_numeric_epoch(value):
         if stripped.removeprefix("-").isdigit():
             return int(stripped)
     return value
+
+
+def _shift_stale_datetime_primary(sample_data, output_columns, tinfo, config):
+    """Shift a stale datetime-typed primary timestamp to 1st-of-current-month UTC.
+
+    Returns True if a datetime primary was found and processed (shifted or fresh),
+    False if no datetime primary exists so the caller can fall through.
+    """
+    if isinstance(sample_data, list):
+        processed = False
+        for row in sample_data:
+            if isinstance(row, dict):
+                if _shift_stale_datetime_primary(row, output_columns, tinfo, config):
+                    processed = True
+        return processed
+
+    primary_key = None
+    primary_fmt = None
+    for col in output_columns:
+        dt = col.get("datatype", {})
+        if dt.get("type") == "datetime" and dt.get("primary"):
+            primary_key = _resolve_sample_key(col, sample_data)
+            primary_fmt = dt.get("format", "")
+            break
+
+    if not primary_key or not primary_fmt:
+        return False
+
+    sample_value = sample_data.get(primary_key)
+    if not isinstance(sample_value, str):
+        return True
+
+    strptime_fmt = _translate_go_layout(primary_fmt)
+    try:
+        parsed = datetime.strptime(sample_value, strptime_fmt).replace(tzinfo=timezone.utc)
+    except (ValueError, re.error):
+        print(
+            f"[Transform Org] Unparseable datetime sample in "
+            f"{os.path.basename(tinfo.final_path)}: format={primary_fmt!r}, "
+            f"value={sample_value!r}",
+            file=sys.stderr,
+        )
+        return True
+    primary_secs = int(calendar.timegm(parsed.timetuple()))
+
+    now_epoch = int(time.time())
+    if now_epoch - primary_secs <= _STALENESS_THRESHOLD_SECS:
+        return True
+
+    now_utc = datetime.now(timezone.utc)
+    first_of_month = now_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    sample_data[primary_key] = first_of_month.strftime(strptime_fmt)
+    return True
 
 
 def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
@@ -328,6 +428,8 @@ def _shift_stale_timestamps(sample_data, transform_data, tinfo, config):
                 primary_format = col_format
 
     if not primary_col or not primary_col[0]:
+        if _shift_stale_datetime_primary(sample_data, output_columns, tinfo, config):
+            return
         if config.verbose:
             print(
                 f"[Transform Org] No primary epoch column found in "

--- a/scripts/configurator/transform_organizer.py
+++ b/scripts/configurator/transform_organizer.py
@@ -16,7 +16,10 @@ from .constants import TRANSFORM_METADATA_FIELDS
 _STALENESS_THRESHOLD_SECS = 183 * 86400
 
 # Go reference time tokens -> strptime directives. Longer tokens first so that a
-# positional scan picks "2006" before "06", "15" before "5", etc.
+# positional scan picks "2006" before "06", "15" before "5", etc. Only padded
+# tokens are supported; a layout using unpadded Go tokens (e.g. "1" for month,
+# "5" for seconds) will produce a wrong strptime pattern and degrade to the
+# warn-and-skip path in _shift_stale_datetime_primary.
 _GO_LAYOUT_TOKENS = (
     ("2006", "%Y"),
     ("01", "%m"),
@@ -352,15 +355,10 @@ def _shift_stale_datetime_primary(sample_data, output_columns, tinfo, config):
 
     Returns True if a datetime primary was found and processed (shifted or fresh),
     False if no datetime primary exists so the caller can fall through.
-    """
-    if isinstance(sample_data, list):
-        processed = False
-        for row in sample_data:
-            if isinstance(row, dict):
-                if _shift_stale_datetime_primary(row, output_columns, tinfo, config):
-                    processed = True
-        return processed
 
+    Assumes sample_data has already been normalized to a dict by the upstream
+    _extract_sample_data (which takes sample_data[0] for list-typed bundles).
+    """
     primary_key = None
     primary_fmt = None
     for col in output_columns:

--- a/src/validate/sample_data_freshness.rs
+++ b/src/validate/sample_data_freshness.rs
@@ -9,6 +9,9 @@ const STALENESS_THRESHOLD_SECS: u64 = 183 * 86400;
 
 /// Go reference-time tokens translated to chrono/strptime directives.
 /// Listed in priority order so a positional scan picks the longest match first.
+/// Only padded tokens are supported; a layout using unpadded Go tokens (e.g.
+/// "1" for month, "5" for seconds) will produce a wrong strptime pattern and
+/// degrade to the skip-on-parse-failure branch below.
 const GO_LAYOUT_TOKENS: &[(&str, &str)] = &[
     ("2006", "%Y"),
     ("01", "%m"),
@@ -112,7 +115,13 @@ pub async fn run(base: &str, bundle: &Bundle) -> Vec<String> {
                     };
                     let strptime_fmt = translate_go_layout(&primary_format);
                     match NaiveDateTime::parse_from_str(&value, &strptime_fmt) {
-                        Ok(dt) => dt.and_utc().timestamp() as u64,
+                        Ok(dt) => {
+                            let ts = dt.and_utc().timestamp();
+                            if ts < 0 {
+                                continue;
+                            }
+                            ts as u64
+                        }
                         Err(_) => continue,
                     }
                 }

--- a/src/validate/sample_data_freshness.rs
+++ b/src/validate/sample_data_freshness.rs
@@ -1,10 +1,48 @@
 use crate::models::bundle::Bundle;
+use chrono::NaiveDateTime;
 use serde_json::Value;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs;
 
 /// Approximately 6 months in seconds (183 days).
 const STALENESS_THRESHOLD_SECS: u64 = 183 * 86400;
+
+/// Go reference-time tokens translated to chrono/strptime directives.
+/// Listed in priority order so a positional scan picks the longest match first.
+const GO_LAYOUT_TOKENS: &[(&str, &str)] = &[
+    ("2006", "%Y"),
+    ("01", "%m"),
+    ("02", "%d"),
+    ("15", "%H"),
+    ("04", "%M"),
+    ("05", "%S"),
+];
+
+/// Translate a Go reference-time layout (e.g. `2006-01-02T15:04:05`) to the
+/// chrono/strftime equivalent (`%Y-%m-%dT%H:%M:%S`). Unknown characters pass
+/// through as literals.
+fn translate_go_layout(fmt: &str) -> String {
+    let mut out = String::new();
+    let mut i = 0;
+    while i < fmt.len() {
+        let rest = &fmt[i..];
+        let mut matched = false;
+        for (go_token, strp_token) in GO_LAYOUT_TOKENS {
+            if rest.starts_with(go_token) {
+                out.push_str(strp_token);
+                i += go_token.len();
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            let ch = rest.chars().next().unwrap_or(' ');
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    out
+}
 
 /// Returns a list of warning messages for stale sample_data timestamps.
 /// An empty list means all timestamps are fresh.
@@ -35,48 +73,69 @@ pub async fn run(base: &str, bundle: &Bundle) -> Vec<String> {
                 None => continue,
             };
 
-            // Find the primary epoch column name and format
+            // Find the primary timestamp column (epoch or datetime) and capture its
+            // type + format so the parse path can dispatch.
             let primary_info = output_columns.iter().find_map(|col| {
                 let dt = col.get("datatype")?;
-                if dt.get("type")?.as_str()? == "epoch" && dt.get("primary")?.as_bool()? {
-                    let name = col.get("name")?.as_str()?.to_string();
+                let type_str = dt.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                let is_ts = type_str == "epoch" || type_str == "datetime";
+                let is_primary = dt.get("primary").and_then(|v| v.as_bool()).unwrap_or(false);
+                if is_ts && is_primary {
+                    let name = col.get("name").and_then(|v| v.as_str())?.to_string();
+                    let default_format = if type_str == "datetime" { "" } else { "s" };
                     let format = dt
                         .get("format")
                         .and_then(|f| f.as_str())
-                        .unwrap_or("s")
+                        .unwrap_or(default_format)
                         .to_string();
-                    Some((name, format))
+                    Some((name, format, type_str.to_string()))
                 } else {
                     None
                 }
             });
 
-            let (primary_col_name, primary_format) = match primary_info {
+            let (primary_col_name, primary_format, primary_type) = match primary_info {
                 Some(info) => info,
                 None => continue,
             };
 
             let sample_data = &transform_json["settings"]["sample_data"];
 
-            let primary_value = match sample_data.get(&primary_col_name) {
-                Some(Value::Number(n)) => match n.as_u64() {
-                    Some(v) => v,
-                    None => match n.as_f64() {
-                        Some(v) => v as u64,
-                        None => continue,
-                    },
-                },
-                _ => continue,
+            let primary_secs: u64 = match primary_type.as_str() {
+                "datetime" => {
+                    if primary_format.is_empty() {
+                        continue;
+                    }
+                    let value = match sample_data.get(&primary_col_name) {
+                        Some(Value::String(s)) => s.clone(),
+                        _ => continue,
+                    };
+                    let strptime_fmt = translate_go_layout(&primary_format);
+                    match NaiveDateTime::parse_from_str(&value, &strptime_fmt) {
+                        Ok(dt) => dt.and_utc().timestamp() as u64,
+                        Err(_) => continue,
+                    }
+                }
+                _ => {
+                    let primary_value = match sample_data.get(&primary_col_name) {
+                        Some(Value::Number(n)) => match n.as_u64() {
+                            Some(v) => v,
+                            None => match n.as_f64() {
+                                Some(v) => v as u64,
+                                None => continue,
+                            },
+                        },
+                        _ => continue,
+                    };
+                    let divisor: u64 = match primary_format.as_str() {
+                        "ms" => 1_000,
+                        "us" => 1_000_000,
+                        "ns" => 1_000_000_000,
+                        _ => 1,
+                    };
+                    primary_value / divisor
+                }
             };
-
-            // Convert to seconds based on format
-            let divisor: u64 = match primary_format.as_str() {
-                "ms" => 1_000,
-                "us" => 1_000_000,
-                "ns" => 1_000_000_000,
-                _ => 1, // "s" or unknown defaults to seconds
-            };
-            let primary_secs = primary_value / divisor;
 
             if now_epoch > primary_secs && (now_epoch - primary_secs) > STALENESS_THRESHOLD_SECS {
                 let age_days = (now_epoch - primary_secs) / 86400;
@@ -215,6 +274,87 @@ mod tests {
         let bundle = make_bundle(transform_path);
         let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
         assert!(!warnings.is_empty(), "Stale data should produce warnings");
+        assert!(
+            warnings[0].contains("Stale sample_data"),
+            "Warning should mention staleness: {}",
+            warnings[0]
+        );
+    }
+
+    fn make_datetime_transform_json(primary_ts: &str, format: &str) -> String {
+        format!(
+            r#"{{
+                "name": "test_transform",
+                "settings": {{
+                    "output_columns": [
+                        {{
+                            "name": "timestamp",
+                            "datatype": {{
+                                "type": "datetime",
+                                "primary": true,
+                                "format": "{format}",
+                                "resolution": "ms"
+                            }}
+                        }}
+                    ],
+                    "sample_data": {{
+                        "timestamp": "{primary_ts}"
+                    }}
+                }}
+            }}"#
+        )
+    }
+
+    #[tokio::test]
+    async fn test_fresh_datetime_data_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let transform_path = "transformations/transform.json";
+        let full_path = dir.path().join(transform_path);
+        fs::create_dir_all(full_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        let fresh = chrono::Utc::now() - chrono::Duration::days(30);
+        let fresh_str = fresh.format("%Y-%m-%dT%H:%M:%S").to_string();
+        fs::write(
+            &full_path,
+            make_datetime_transform_json(&fresh_str, "2006-01-02T15:04:05"),
+        )
+        .await
+        .unwrap();
+
+        let bundle = make_bundle(transform_path);
+        let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
+        assert!(
+            warnings.is_empty(),
+            "Fresh datetime should produce no warnings: {:?}",
+            warnings
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stale_datetime_data_warns() {
+        let dir = tempfile::tempdir().unwrap();
+        let transform_path = "transformations/transform.json";
+        let full_path = dir.path().join(transform_path);
+        fs::create_dir_all(full_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        // Stale: well over 5 years old regardless of when the test runs
+        fs::write(
+            &full_path,
+            make_datetime_transform_json("2020-06-15T12:34:56", "2006-01-02T15:04:05"),
+        )
+        .await
+        .unwrap();
+
+        let bundle = make_bundle(transform_path);
+        let warnings = run(dir.path().to_str().unwrap(), &bundle).await;
+        assert!(
+            !warnings.is_empty(),
+            "Stale datetime should produce warnings"
+        );
         assert!(
             warnings[0].contains("Stale sample_data"),
             "Warning should mention staleness: {}",

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -709,49 +709,6 @@ class TestDatetimePrimary:
 
         assert sample["timestamp"] == fresh_value
 
-    def test_datetime_list_sample_each_row_shifted(self, tmp_path):
-        """List-typed sample_data: every row's datetime primary shifted independently.
-
-        Mirrors Fastly bundles whose sample_data is a list of rows rather than
-        a single dict. Each row's primary drives its own shift (per ticket), so
-        every row's primary lands on the 1st of the current month UTC. Non-datetime
-        fields are untouched per row.
-        """
-        stale1 = "2020-06-15T12:34:56"
-        stale2 = "2020-07-20T08:15:30"
-        data = {
-            "settings": {
-                "output_columns": [
-                    {
-                        "name": "timestamp",
-                        "datatype": {
-                            "type": "datetime",
-                            "primary": True,
-                            "format": "2006-01-02T15:04:05",
-                        },
-                    },
-                ],
-                "sample_data": [
-                    {"timestamp": stale1, "bytes": 100},
-                    {"timestamp": stale2, "bytes": 200},
-                ],
-            }
-        }
-        sample = data["settings"]["sample_data"]
-        config = _make_config(tmp_path)
-        tinfo = _make_tinfo(tmp_path)
-
-        _shift_stale_timestamps(sample, data, tinfo, config)
-
-        now_utc = datetime.now(timezone.utc)
-        expected = now_utc.replace(
-            day=1, hour=0, minute=0, second=0, microsecond=0
-        ).strftime("%Y-%m-%dT%H:%M:%S")
-        assert sample[0]["timestamp"] == expected
-        assert sample[1]["timestamp"] == expected
-        assert sample[0]["bytes"] == 100
-        assert sample[1]["bytes"] == 200
-
     def test_datetime_null_primary_resolves_via_from_input_field(self, tmp_path):
         """Cloudflare case: output 'timestamp' is null; raw key 'EdgeStartTimestamp' gets shifted.
 

--- a/tests/test_timestamp_freshness.py
+++ b/tests/test_timestamp_freshness.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 import types
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 import calendar
 
@@ -641,3 +641,213 @@ class TestShiftWithJsonPointer:
         _shift_stale_timestamps(sample, data, tinfo, config)
 
         assert sample["some_other_field"] == stale_ts
+
+
+# ---------------------------------------------------------------------------
+# Datetime-typed primary columns (Go reference time layouts) — LOTC-1447
+# ---------------------------------------------------------------------------
+
+
+class TestDatetimePrimary:
+    """Shift behavior for datatype.type == 'datetime' primaries with Go-layout formats."""
+
+    def test_datetime_stale_sample_shifted_to_first_of_month(self, tmp_path):
+        """Stale datetime primary shifted to 1st of current month UTC, same Go layout."""
+        stale_value = "2020-06-15T12:34:56"  # always well past the 183-day threshold
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            "format": "2006-01-02T15:04:05",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": stale_value},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        now_utc = datetime.now(timezone.utc)
+        expected = now_utc.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        assert sample["timestamp"] == expected
+
+    def test_datetime_fresh_sample_not_shifted(self, tmp_path):
+        """Fresh datetime primary (within 183 days) passes through untouched."""
+        fresh_value = (
+            datetime.now(timezone.utc) - timedelta(days=30)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            "format": "2006-01-02T15:04:05",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": fresh_value},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == fresh_value
+
+    def test_datetime_list_sample_each_row_shifted(self, tmp_path):
+        """List-typed sample_data: every row's datetime primary shifted independently.
+
+        Mirrors Fastly bundles whose sample_data is a list of rows rather than
+        a single dict. Each row's primary drives its own shift (per ticket), so
+        every row's primary lands on the 1st of the current month UTC. Non-datetime
+        fields are untouched per row.
+        """
+        stale1 = "2020-06-15T12:34:56"
+        stale2 = "2020-07-20T08:15:30"
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            "format": "2006-01-02T15:04:05",
+                        },
+                    },
+                ],
+                "sample_data": [
+                    {"timestamp": stale1, "bytes": 100},
+                    {"timestamp": stale2, "bytes": 200},
+                ],
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        now_utc = datetime.now(timezone.utc)
+        expected = now_utc.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        assert sample[0]["timestamp"] == expected
+        assert sample[1]["timestamp"] == expected
+        assert sample[0]["bytes"] == 100
+        assert sample[1]["bytes"] == 200
+
+    def test_datetime_null_primary_resolves_via_from_input_field(self, tmp_path):
+        """Cloudflare case: output 'timestamp' is null; raw key 'EdgeStartTimestamp' gets shifted.
+
+        The primary datetime column declares a source of from_input_field pointing
+        at the raw vendor key. The output column exists in sample_data but its value
+        is null, so the resolver must fall through to the raw key.
+        """
+        stale_value = "2020-06-15T12:34:56Z"
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            "format": "2006-01-02T15:04:05Z",
+                            "source": {"from_input_field": "EdgeStartTimestamp"},
+                        },
+                    },
+                ],
+                "sample_data": {
+                    "timestamp": None,
+                    "EdgeStartTimestamp": stale_value,
+                },
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        now_utc = datetime.now(timezone.utc)
+        expected = now_utc.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert sample["EdgeStartTimestamp"] == expected
+        assert sample["timestamp"] is None
+
+    def test_datetime_unparseable_format_warn_and_skip(self, tmp_path, capsys):
+        """Malformed Go layout (Tencent typo) must warn and leave sample_data alone."""
+        stale_value = "2020-06-15T12:34:56Z"
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            # Invalid Go layout: "15:05:05" collides on minutes/seconds
+                            "format": "2006-01-02T15:05:05Z",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": stale_value},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path, verbose=True)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        # Sample unchanged, no exception raised
+        assert sample["timestamp"] == stale_value
+        # Warning emitted
+        captured = capsys.readouterr()
+        assert "Unparseable datetime sample" in captured.err
+
+    def test_datetime_format_sample_mismatch_warn_and_skip(self, tmp_path, capsys):
+        """Sample value does not match declared format (Cloudflare trailing Z) — warn + skip."""
+        # Format lacks trailing literal Z; sample has one -> strptime ValueError
+        stale_value = "2020-06-15T12:34:56Z"
+        data = {
+            "settings": {
+                "output_columns": [
+                    {
+                        "name": "timestamp",
+                        "datatype": {
+                            "type": "datetime",
+                            "primary": True,
+                            "format": "2006-01-02T15:04:05",
+                        },
+                    },
+                ],
+                "sample_data": {"timestamp": stale_value},
+            }
+        }
+        sample = data["settings"]["sample_data"]
+        config = _make_config(tmp_path, verbose=True)
+        tinfo = _make_tinfo(tmp_path)
+
+        _shift_stale_timestamps(sample, data, tinfo, config)
+
+        assert sample["timestamp"] == stale_value
+        captured = capsys.readouterr()
+        assert "Unparseable datetime sample" in captured.err


### PR DESCRIPTION
## Summary

Extends the pipeline's timestamp shifter and the Rust freshness validator to handle primary columns declared with `datatype.type == "datetime"` (Go-layout formats like `2006-01-02T15:04:05`). Before this PR, only `type == "epoch"` was handled, so 6 bundles (Fastly/Cloudflare/Tencent bot- and cdn-insights) silently bypassed shifting and — since LOTC-1438 landed — hard-fail CI with empty test tables.

Jira: [LOTC-1447](https://hydrolix.atlassian.net/browse/LOTC-1447)

## Changes

- `scripts/configurator/transform_organizer.py`
  - `_translate_go_layout` — maps Go reference-time tokens (`2006`, `01`, `02`, `15`, `04`, `05`) to `strptime` directives via a positional, longest-first scan.
  - `_shift_stale_datetime_primary` — parses the primary datetime value, shifts to 1st-of-current-month UTC when older than 183 days, reformats in the original Go layout. Warns-and-skips on unparseable formats or format/sample mismatches (e.g. Tencent's `15:05:05` typo, Cloudflare's trailing-`Z` mismatch) rather than crashing the pipeline.
  - `_resolve_sample_key` — prefers the output column name only when its value is non-null; falls through to single-segment `from_json_pointers`, then to `from_input_field` (the shape Cloudflare uses for `EdgeStartTimestamp`). Last-resort returns `col_name` if present, preserving every pre-existing caller's outcome.

- `src/validate/sample_data_freshness.rs`
  - Mirror Go-layout translator and chrono-backed datetime parse path. Primary-column lookup accepts both `epoch` and `datetime` types. Guards against pre-1970 negative timestamps before casting to `u64`.

- Tests
  - 5 new Python tests in `TestDatetimePrimary` (stale → shifted, fresh → untouched, null-primary via `from_input_field`, unparseable format, format/sample mismatch).
  - 2 new Rust tests (`test_stale_datetime_data_warns`, `test_fresh_datetime_data_passes`).

## Out of scope (per ticket)

- Regenerating the 6 affected bundles' `sample_data` — separate follow-up PR once this merges.
- Regex-format primaries (zuplo) — tracked separately.

## Test plan

- [x] `python3 -m pytest tests/` — 115 passed
- [x] `cargo test` — all Rust tests pass
- [x] `cargo fmt --check` — clean
- [ ] Post-merge: re-run configure pipeline on Fastly bundles and verify `sample_data.json` contains current-month timestamps
- [ ] Post-merge: `cargo run -- --local --guid bot_insights_fastly` passes LOTC-1438's `verify_rows_ingested_if_present`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOTC-1447]: https://hydrolix.atlassian.net/browse/LOTC-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ