### PR TITLE
Add TrafficPeak APIContext bundle

### DIFF
--- a/portables/trafficpeak/apicontext/1.0.0/apicontext.bdl.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/apicontext.bdl.yaml
@@ -1,0 +1,10 @@
+name: trafficpeak_apicontext
+version: 1.0.0
+description: TRAFFICPEAK Apicontext integration bundle
+maintainer: Hydrolix Team <team@hydrolix.io>
+hydrolix:
+  resources: hydrolix/resources.hdp.yaml
+grafana:
+  resources: grafana/resources.gfo.yaml
+
+# additional properties, metadata of a bundle

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
@@ -1,73 +1,73 @@
 {
+  "__elements": {},
   "__inputs": [
     {
-      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
-      "label": "Hydrolix",
       "description": "",
-      "type": "datasource",
+      "label": "Hydrolix",
+      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
       "pluginId": "hydrolix-hydrolix-datasource",
       "pluginName": "Hydrolix",
+      "type": "datasource",
       "value": "__DATASOURCE__"
     },
     {
+      "description": "",
+      "label": "timestamp",
       "name": "VAR_TIMESTAMP",
       "type": "constant",
-      "label": "timestamp",
-      "value": "startTime",
-      "description": ""
+      "value": "startTime"
     },
     {
+      "description": "",
+      "label": "apicontext_sampled_day",
       "name": "VAR_APICONTEXT_SAMPLED_DAY",
       "type": "constant",
-      "label": "apicontext_sampled_day",
-      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
-      "description": ""
+      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
     },
     {
+      "description": "",
+      "label": "logs",
       "name": "VAR_LOGS",
       "type": "constant",
-      "label": "logs",
-      "value": "akamai.apicontext",
-      "description": ""
+      "value": "akamai.apicontext"
     },
     {
+      "description": "",
+      "label": "siem",
       "name": "VAR_SIEM",
       "type": "constant",
-      "label": "siem",
-      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__",
-      "description": ""
+      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__"
     }
   ],
-  "__elements": {},
   "__requires": [
     {
-      "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
+      "type": "grafana",
       "version": "12.0.2"
     },
     {
-      "type": "datasource",
       "id": "hydrolix-hydrolix-datasource",
       "name": "Hydrolix",
+      "type": "datasource",
       "version": "0.6.0"
     },
     {
-      "type": "panel",
       "id": "piechart",
       "name": "Pie chart",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "text",
       "name": "Text",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "type": "panel",
       "version": ""
     }
   ],
@@ -232,7 +232,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -353,7 +353,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -470,7 +470,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -669,7 +669,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -786,7 +786,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -903,7 +903,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1020,7 +1020,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1137,7 +1137,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1254,7 +1254,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1371,7 +1371,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1488,7 +1488,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1605,7 +1605,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1641,23 +1641,23 @@
         "type": "query"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "${VAR_TIMESTAMP}",
+          "value": "${VAR_TIMESTAMP}"
+        },
         "hide": 2,
         "name": "timestamp",
-        "query": "${VAR_TIMESTAMP}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_TIMESTAMP}",
-          "text": "${VAR_TIMESTAMP}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_TIMESTAMP}",
+            "selected": false,
             "text": "${VAR_TIMESTAMP}",
-            "selected": false
+            "value": "${VAR_TIMESTAMP}"
           }
-        ]
+        ],
+        "query": "${VAR_TIMESTAMP}",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
         "baseFilters": [],
@@ -1681,42 +1681,42 @@
         "type": "query"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "__SUMMARY_TABLE_NAME_1__",
+          "value": "__SUMMARY_TABLE_NAME_1__"
+        },
         "hide": 2,
         "name": "apicontext_sampled_day",
+        "options": [
+          {
+            "selected": false,
+            "text": "__SUMMARY_TABLE_NAME_1__",
+            "value": "__SUMMARY_TABLE_NAME_1__"
+          }
+        ],
         "query": "__SUMMARY_TABLE_NAME_1__",
         "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "__SUMMARY_TABLE_NAME_1__",
-          "text": "__SUMMARY_TABLE_NAME_1__",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "__SUMMARY_TABLE_NAME_1__",
-            "text": "__SUMMARY_TABLE_NAME_1__",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "__PROJECT_NAME__.__TABLE_NAME__",
+          "value": "__PROJECT_NAME__.__TABLE_NAME__"
+        },
         "hide": 2,
         "name": "logs",
-        "query": "__PROJECT_NAME__.__TABLE_NAME__",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "__PROJECT_NAME__.__TABLE_NAME__",
-          "text": "__PROJECT_NAME__.__TABLE_NAME__",
-          "selected": false
-        },
         "options": [
           {
-            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false,
             "text": "__PROJECT_NAME__.__TABLE_NAME__",
-            "selected": false
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
           }
-        ]
+        ],
+        "query": "__PROJECT_NAME__.__TABLE_NAME__",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
         "current": {},

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
@@ -1,0 +1,1831 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
+      "label": "Hydrolix",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "hydrolix-hydrolix-datasource",
+      "pluginName": "Hydrolix",
+      "value": "__DATASOURCE__"
+    },
+    {
+      "name": "VAR_TIMESTAMP",
+      "type": "constant",
+      "label": "timestamp",
+      "value": "startTime",
+      "description": ""
+    },
+    {
+      "name": "VAR_APICONTEXT_SAMPLED_DAY",
+      "type": "constant",
+      "label": "apicontext_sampled_day",
+      "value": "__PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__",
+      "description": ""
+    },
+    {
+      "name": "VAR_LOGS",
+      "type": "constant",
+      "label": "logs",
+      "value": "akamai.apicontext",
+      "description": ""
+    },
+    {
+      "name": "VAR_SIEM",
+      "type": "constant",
+      "label": "siem",
+      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "hydrolix-hydrolix-datasource",
+      "name": "Hydrolix",
+      "version": "0.6.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Reports on network times, number of requests by categories, status codes, and location ID's.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "API Observability",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 18,
+      "panels": [],
+      "title": "All data within this dashboard is from public endpoints of various domains",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Number of request group by HTTP Status Code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Total",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP codes",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Number of requests per Context Category.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Total",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "hoverProximity": 1,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Categories",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Average Response Time Along Time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average response time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Total Count and Percentage per Localtion ID.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  locationID,\n  ${cnt_all}\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY locationID\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top location IDs; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Top location IDs",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Average DNS Time Along Time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average DNS lookup time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the Connect average time along time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average TCP connect time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the average time for tlsHandshake.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average SSL handshake time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of tlsHandshake, connect, and dns times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Total networking time (DNS + TCP + SSL)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of connect, tlsHandshake, and upload times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "It shows the sum of the averages of tlsHandshake, connect, and dns.",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of dns, connect, tlsHandshake, and upload times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Total time until first byte (including networking time)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of connect, tlsHandshake, and upload times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Total time until first byte (excluding DNS)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of connect, tlsHandshake,upload, and processing times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Total time (excluding DNS)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of dns, connect, tlsHandshake,  and download times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Total time (including DNS)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [
+    "v1.0",
+    "Required tables: apicontext_sampled_day"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "definition": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+        "hide": 2,
+        "name": "table",
+        "options": [],
+        "query": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "name": "timestamp",
+        "query": "${VAR_TIMESTAMP}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TIMESTAMP}",
+          "text": "${VAR_TIMESTAMP}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TIMESTAMP}",
+            "text": "${VAR_TIMESTAMP}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "baseFilters": [],
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+        },
+        "filters": [],
+        "name": "filter",
+        "type": "adhoc"
+      },
+      {
+        "current": {},
+        "definition": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+        "hide": 2,
+        "name": "duration",
+        "options": [],
+        "query": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "name": "apicontext_sampled_day",
+        "query": "__APICONTEXT_SAMPLED_DAY__",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "__APICONTEXT_SAMPLED_DAY__",
+          "text": "__APICONTEXT_SAMPLED_DAY__",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "__APICONTEXT_SAMPLED_DAY__",
+            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "name": "logs",
+        "query": "__PROJECT_NAME__.__TABLE_NAME__",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "__PROJECT_NAME__.__TABLE_NAME__",
+          "text": "__PROJECT_NAME__.__TABLE_NAME__",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+        "hide": 2,
+        "name": "cnt_all",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+        "hide": 2,
+        "name": "avg_responseTime",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+        "hide": 2,
+        "name": "avg_dns_lookup_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+        "hide": 2,
+        "name": "avg_tcp_connect_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+        "hide": 2,
+        "name": "avg_tls_handshake_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(upload)',\n'avg_upload_time'\n)",
+        "hide": 2,
+        "name": "avg_upload_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(upload)',\n'avg_upload_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+        "hide": 2,
+        "name": "avg_processing_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(download)',\n'avg_download_time'\n)",
+        "hide": 2,
+        "name": "avg_download_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(download)',\n'avg_download_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "nowDelay": "1m",
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "API observability",
+  "version": 9,
+  "weekStart": ""
+}

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/api_observability.json
@@ -20,7 +20,7 @@
       "name": "VAR_APICONTEXT_SAMPLED_DAY",
       "type": "constant",
       "label": "apicontext_sampled_day",
-      "value": "__PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__",
+      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
       "description": ""
     },
     {
@@ -1683,18 +1683,18 @@
       {
         "hide": 2,
         "name": "apicontext_sampled_day",
-        "query": "__APICONTEXT_SAMPLED_DAY__",
+        "query": "__SUMMARY_TABLE_NAME_1__",
         "skipUrlSync": true,
         "type": "constant",
         "current": {
-          "value": "__APICONTEXT_SAMPLED_DAY__",
-          "text": "__APICONTEXT_SAMPLED_DAY__",
+          "value": "__SUMMARY_TABLE_NAME_1__",
+          "text": "__SUMMARY_TABLE_NAME_1__",
           "selected": false
         },
         "options": [
           {
-            "value": "__APICONTEXT_SAMPLED_DAY__",
-            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "value": "__SUMMARY_TABLE_NAME_1__",
+            "text": "__SUMMARY_TABLE_NAME_1__",
             "selected": false
           }
         ]

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
@@ -20,7 +20,7 @@
       "name": "VAR_APICONTEXT_SAMPLED_DAY",
       "type": "constant",
       "label": "apicontext_sampled_day",
-      "value": "__PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__",
+      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
       "description": ""
     },
     {
@@ -2495,18 +2495,18 @@
       {
         "hide": 2,
         "name": "apicontext_sampled_day",
-        "query": "__APICONTEXT_SAMPLED_DAY__",
+        "query": "__SUMMARY_TABLE_NAME_1__",
         "skipUrlSync": true,
         "type": "constant",
         "current": {
-          "value": "__APICONTEXT_SAMPLED_DAY__",
-          "text": "__APICONTEXT_SAMPLED_DAY__",
+          "value": "__SUMMARY_TABLE_NAME_1__",
+          "text": "__SUMMARY_TABLE_NAME_1__",
           "selected": false
         },
         "options": [
           {
-            "value": "__APICONTEXT_SAMPLED_DAY__",
-            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "value": "__SUMMARY_TABLE_NAME_1__",
+            "text": "__SUMMARY_TABLE_NAME_1__",
             "selected": false
           }
         ]

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
@@ -1,91 +1,91 @@
 {
+  "__elements": {},
   "__inputs": [
     {
-      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
-      "label": "Hydrolix",
       "description": "",
-      "type": "datasource",
+      "label": "Hydrolix",
+      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
       "pluginId": "hydrolix-hydrolix-datasource",
       "pluginName": "Hydrolix",
+      "type": "datasource",
       "value": "__DATASOURCE__"
     },
     {
+      "description": "",
+      "label": "timestamp",
       "name": "VAR_TIMESTAMP",
       "type": "constant",
-      "label": "timestamp",
-      "value": "startTime",
-      "description": ""
+      "value": "startTime"
     },
     {
+      "description": "",
+      "label": "apicontext_sampled_day",
       "name": "VAR_APICONTEXT_SAMPLED_DAY",
       "type": "constant",
-      "label": "apicontext_sampled_day",
-      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
-      "description": ""
+      "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
     },
     {
+      "description": "",
+      "label": "logs",
       "name": "VAR_LOGS",
       "type": "constant",
-      "label": "logs",
-      "value": "akamai.apicontext",
-      "description": ""
+      "value": "akamai.apicontext"
     },
     {
+      "description": "",
+      "label": "siem",
       "name": "VAR_SIEM",
       "type": "constant",
-      "label": "siem",
-      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__",
-      "description": ""
+      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__"
     }
   ],
-  "__elements": {},
   "__requires": [
     {
-      "type": "panel",
       "id": "barchart",
       "name": "Bar chart",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "geomap",
       "name": "Geomap",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
+      "type": "grafana",
       "version": "12.0.2"
     },
     {
-      "type": "datasource",
       "id": "hydrolix-hydrolix-datasource",
       "name": "Hydrolix",
+      "type": "datasource",
       "version": "0.6.0"
     },
     {
-      "type": "panel",
       "id": "piechart",
       "name": "Pie chart",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "table",
       "name": "Table",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "text",
       "name": "Text",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "type": "panel",
       "version": ""
     }
   ],
@@ -575,7 +575,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -697,7 +697,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -819,7 +819,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
           "refId": "A"
         }
       ],
@@ -941,7 +941,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -1063,7 +1063,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
           "refId": "A"
         }
       ],
@@ -1185,7 +1185,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
           "refId": "A"
         }
       ],
@@ -2035,7 +2035,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "timeseries",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
           "refId": "A"
         }
       ],
@@ -2324,7 +2324,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
           "refId": "A"
         }
       ],
@@ -2453,23 +2453,23 @@
         "type": "query"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "${VAR_TIMESTAMP}",
+          "value": "${VAR_TIMESTAMP}"
+        },
         "hide": 2,
         "name": "timestamp",
-        "query": "${VAR_TIMESTAMP}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_TIMESTAMP}",
-          "text": "${VAR_TIMESTAMP}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_TIMESTAMP}",
+            "selected": false,
             "text": "${VAR_TIMESTAMP}",
-            "selected": false
+            "value": "${VAR_TIMESTAMP}"
           }
-        ]
+        ],
+        "query": "${VAR_TIMESTAMP}",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
         "baseFilters": [],
@@ -2493,42 +2493,42 @@
         "type": "query"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+          "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
+        },
         "hide": 2,
         "name": "apicontext_sampled_day",
-        "query": "__SUMMARY_TABLE_NAME_1__",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "__SUMMARY_TABLE_NAME_1__",
-          "text": "__SUMMARY_TABLE_NAME_1__",
-          "selected": false
-        },
         "options": [
           {
-            "value": "__SUMMARY_TABLE_NAME_1__",
-            "text": "__SUMMARY_TABLE_NAME_1__",
-            "selected": false
+            "selected": false,
+            "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+            "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
           }
-        ]
+        ],
+        "query": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "__PROJECT_NAME__.__TABLE_NAME__",
+          "value": "__PROJECT_NAME__.__TABLE_NAME__"
+        },
         "hide": 2,
         "name": "logs",
-        "query": "__PROJECT_NAME__.__TABLE_NAME__",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "__PROJECT_NAME__.__TABLE_NAME__",
-          "text": "__PROJECT_NAME__.__TABLE_NAME__",
-          "selected": false
-        },
         "options": [
           {
-            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false,
             "text": "__PROJECT_NAME__.__TABLE_NAME__",
-            "selected": false
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
           }
-        ]
+        ],
+        "query": "__PROJECT_NAME__.__TABLE_NAME__",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
         "current": {},

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/dashboards/network_monitoring_dashboard_synthetics.json
@@ -1,0 +1,2753 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX-HYDROLIX-DATASOURCE",
+      "label": "Hydrolix",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "hydrolix-hydrolix-datasource",
+      "pluginName": "Hydrolix",
+      "value": "__DATASOURCE__"
+    },
+    {
+      "name": "VAR_TIMESTAMP",
+      "type": "constant",
+      "label": "timestamp",
+      "value": "startTime",
+      "description": ""
+    },
+    {
+      "name": "VAR_APICONTEXT_SAMPLED_DAY",
+      "type": "constant",
+      "label": "apicontext_sampled_day",
+      "value": "__PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__",
+      "description": ""
+    },
+    {
+      "name": "VAR_LOGS",
+      "type": "constant",
+      "label": "logs",
+      "value": "akamai.apicontext",
+      "description": ""
+    },
+    {
+      "name": "VAR_SIEM",
+      "type": "constant",
+      "label": "siem",
+      "value": "__PROJECT_NAME__.__SIEM_TABLE_NAME__",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "geomap",
+      "name": "Geomap",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "hydrolix-hydrolix-datasource",
+      "name": "Hydrolix",
+      "version": "0.6.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "description": "",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Reports on network times, multi-cloud information, and API workflows.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "Network Monitoring Dashboard (Synthetics)",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows network issues and for each Cloud and Region",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1-green": {
+                  "color": "green",
+                  "index": 2
+                },
+                "2-yellow": {
+                  "color": "orange",
+                  "index": 1
+                },
+                "3-red": {
+                  "color": "dark-red",
+                  "index": 0
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 19,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 17,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "arrow": 1,
+              "edgeStyle": {
+                "color": {
+                  "field": "edge_color_text",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "edge_thickness",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "text": {
+                  "field": "network_time",
+                  "fixed": "",
+                  "mode": "field"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              },
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "field": "cloud_provider",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "cloud_provider",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "latitude": "latitude",
+              "longitude": "longitude",
+              "mode": "coords"
+            },
+            "name": "Layer 3",
+            "tooltip": true,
+            "type": "network"
+          },
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "field": "cloud_provider",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "network_time",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "text": {
+                  "field": "cloud_provider",
+                  "fixed": "",
+                  "mode": "field"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "right",
+                  "textBaseline": "bottom"
+                }
+              }
+            },
+            "filterData": {
+              "id": "byRefId",
+              "options": "nodes"
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Layer 2",
+            "tooltip": true,
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "coords",
+          "lat": 15.767144,
+          "lon": -1.234589,
+          "zoom": 2
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "builderOptions": {
+            "aggregates": [],
+            "columns": [
+              {
+                "custom": false,
+                "name": "call_id",
+                "type": "String"
+              }
+            ],
+            "database": "default",
+            "filters": [],
+            "groupBy": [],
+            "limit": 1000,
+            "meta": {},
+            "mode": "list",
+            "orderBy": [],
+            "queryType": "table",
+            "table": "apic2"
+          },
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "hide": false,
+          "meta": {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "call_id",
+                  "type": "String"
+                }
+              ],
+              "database": "default",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "apic2"
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT \n    CONCAT(callID, '_', resultID) AS id,  \n    ipAddr AS ip_address,\n    ${ipAddr_latitude} AS latitude,  \n    ${ipAddr_longitude} AS longitude,\n    cloud AS cloud_provider,\n    ${ipAddr_city} AS city\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND ipAddr != '~~~SAMPLED_OUT~~~'\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND notEmpty(cloud_provider)\nAND NOT (\n    -- Exclude Private IPs\n    ipAddr LIKE '10.%' OR ipAddr LIKE '172.16.%' OR ipAddr LIKE '172.17.%' OR ipAddr LIKE '172.18.%' \n    OR ipAddr LIKE '172.19.%' OR ipAddr LIKE '172.20.%' OR ipAddr LIKE '172.21.%' OR ipAddr LIKE '172.22.%' \n    OR ipAddr LIKE '172.23.%' OR ipAddr LIKE '172.24.%' OR ipAddr LIKE '172.25.%' OR ipAddr LIKE '172.26.%' \n    OR ipAddr LIKE '172.27.%' OR ipAddr LIKE '172.28.%' OR ipAddr LIKE '172.29.%' OR ipAddr LIKE '172.30.%' \n    OR ipAddr LIKE '172.31.%' OR ipAddr LIKE '192.168.%' OR ipAddr LIKE '169.254.%' OR ipAddr LIKE '127.%'\n)\nLIMIT 300\n\nUNION ALL \n\nSELECT DISTINCT \n    CONCAT(resultID, '_', callID) AS id,  \n    targetIPAddr AS ip_address,\n    ${targetIPAddr_latitude} AS latitude,  \n    ${targetIPAddr_longitude} AS longitude,\n    targetCloud AS cloud_provider,\n    ${targetIPAddr_city} AS city\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND targetIPAddr != '~~~SAMPLED_OUT~~~'\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND notEmpty(cloud_provider)\nAND NOT (\n    -- Exclude Private IPs\n    targetIPAddr LIKE '10.%' OR targetIPAddr LIKE '172.16.%' OR targetIPAddr LIKE '172.17.%' OR targetIPAddr LIKE '172.18.%' \n    OR targetIPAddr LIKE '172.19.%' OR targetIPAddr LIKE '172.20.%' OR targetIPAddr LIKE '172.21.%' OR targetIPAddr LIKE '172.22.%' \n    OR targetIPAddr LIKE '172.23.%' OR targetIPAddr LIKE '172.24.%' OR targetIPAddr LIKE '172.25.%' OR targetIPAddr LIKE '172.26.%' \n    OR targetIPAddr LIKE '172.27.%' OR targetIPAddr LIKE '172.28.%' OR targetIPAddr LIKE '172.29.%' OR targetIPAddr LIKE '172.30.%' \n    OR targetIPAddr LIKE '172.31.%' OR targetIPAddr LIKE '192.168.%' OR targetIPAddr LIKE '169.254.%' OR targetIPAddr LIKE '127.%'\n)\n\nORDER BY id\nLIMIT 300\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking issues for all API calls; query=nodes; du=${__user.login}'",
+          "refId": "nodes"
+        },
+        {
+          "builderOptions": {
+            "aggregates": [],
+            "columns": [
+              {
+                "custom": false,
+                "name": "call_id",
+                "type": "String"
+              }
+            ],
+            "database": "default",
+            "filters": [],
+            "groupBy": [],
+            "limit": 1000,
+            "meta": {},
+            "mode": "list",
+            "orderBy": [],
+            "queryType": "table",
+            "table": "apic2"
+          },
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "hide": false,
+          "meta": {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "call_id",
+                  "type": "String"
+                }
+              ],
+              "database": "default",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "apic2"
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n    CONCAT(callID, '_', resultID) AS source,   -- 👈 Ensure this matches the node ID\n    CONCAT(resultID, '_', callID) AS target,   -- 👈 Ensure this matches the node ID\n    (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) AS network_time, -- Network Time Calculation\n    cloud AS source_cloud, \n    targetCloud AS target_cloud, \n    ${ipAddr_city} AS source_city, \n    ${targetIPAddr_city} AS target_city,\n\n    -- 🚦 Edge Coloring Logic\n    CASE \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) < 50 THEN '1-green'   \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) BETWEEN 50 AND 200 THEN '2-yellow'  \n        ELSE '3-red'   \n    END AS edge_color_text,\n\n    -- 🔹 Edge Thickness based on Performance\n    CASE \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) < 50 THEN 2  \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) BETWEEN 50 AND 200 THEN 4  \n        ELSE 6  \n    END AS edge_thickness\n\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND isNotNull(targetIPAddr)\nAND notEmpty(targetIPAddr)\nAND isNotNull(ipAddr)\nAND notEmpty(target_city)\n\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND NOT (\n    -- Exclude Private IPs (Source)\n    ipAddr LIKE '10.%'\n    OR ipAddr LIKE '172.16.%' OR ipAddr LIKE '172.17.%' OR ipAddr LIKE '172.18.%' OR ipAddr LIKE '172.19.%'\n    OR ipAddr LIKE '172.20.%' OR ipAddr LIKE '172.21.%' OR ipAddr LIKE '172.22.%' OR ipAddr LIKE '172.23.%'\n    OR ipAddr LIKE '172.24.%' OR ipAddr LIKE '172.25.%' OR ipAddr LIKE '172.26.%' OR ipAddr LIKE '172.27.%'\n    OR ipAddr LIKE '172.28.%' OR ipAddr LIKE '172.29.%' OR ipAddr LIKE '172.30.%' OR ipAddr LIKE '172.31.%'\n    OR ipAddr LIKE '192.168.%'\n    OR ipAddr LIKE '169.254.%'\n    OR ipAddr LIKE '127.%'\n\n    -- Exclude Private IPs (Target)\n    OR targetIPAddr LIKE '10.%'\n    OR targetIPAddr LIKE '172.16.%' OR targetIPAddr LIKE '172.17.%' OR targetIPAddr LIKE '172.18.%' OR targetIPAddr LIKE '172.19.%'\n    OR targetIPAddr LIKE '172.20.%' OR targetIPAddr LIKE '172.21.%' OR targetIPAddr LIKE '172.22.%' OR targetIPAddr LIKE '172.23.%'\n    OR targetIPAddr LIKE '172.24.%' OR targetIPAddr LIKE '172.25.%' OR targetIPAddr LIKE '172.26.%' OR targetIPAddr LIKE '172.27.%'\n    OR targetIPAddr LIKE '172.28.%' OR targetIPAddr LIKE '172.29.%' OR targetIPAddr LIKE '172.30.%' OR targetIPAddr LIKE '172.31.%'\n    OR targetIPAddr LIKE '192.168.%'\n    OR targetIPAddr LIKE '169.254.%'\n    OR targetIPAddr LIKE '127.%'\n)\nGROUP BY source, target, source_cloud, target_cloud, source_city, target_city, startTime\nORDER BY ${timestamp} DESC  -- 🕒 Sort by most recent data\nLIMIT 300  -- 📉 Keep results manageable\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking issues for all API calls; query=edges; du=${__user.login}'",
+          "refId": "edges"
+        }
+      ],
+      "title": "Networking issues for all API calls",
+      "type": "geomap"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the average Connect time for each metadataDomain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average TCP connect time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the average tlsHandshake time for each metadataDomain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average SSL handshake time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the average DNS time for each Metadata Domain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Average DNS lookup time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the average Response Time for each Metadata Domain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Average response time",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the sum of the averages of TlsHandshake, Connect, and DNS for each Metadata Domain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Total networking time (DNS + TCP + SSL)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the Cloud, Connect, and DNS average time for each Cloud.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Total networking time (By Cloud)",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the Average Response Time groping by Location ID and cloud.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "AWS": {
+                  "color": "orange",
+                  "index": 1
+                },
+                "Akamai": {
+                  "color": "yellow",
+                  "index": 2
+                },
+                "Azure": {
+                  "color": "blue",
+                  "index": 0
+                },
+                "Google": {
+                  "color": "green",
+                  "index": 4
+                },
+                "IBM": {
+                  "color": "red",
+                  "index": 3
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "latitude"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "longitude"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "id": 6,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "field": "cloud",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "AvgResponseTime",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Latency",
+            "tooltip": true,
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "builderOptions": {
+            "aggregates": [
+              {
+                "aggregateType": "avg",
+                "alias": "AvgResponseTime",
+                "column": "dns"
+              }
+            ],
+            "columns": [
+              {
+                "custom": false,
+                "name": "latitude",
+                "type": "Nullable(String)"
+              },
+              {
+                "custom": false,
+                "name": "longitude",
+                "type": "Nullable(String)"
+              },
+              {
+                "custom": false,
+                "name": "cloud",
+                "type": "Nullable(String)"
+              },
+              {
+                "custom": false,
+                "name": "locationID",
+                "type": "Nullable(String)"
+              }
+            ],
+            "database": "apicontext",
+            "filters": [
+              {
+                "condition": "AND",
+                "filterType": "custom",
+                "key": "startTime",
+                "operator": "WITH IN DASHBOARD TIME RANGE",
+                "type": "DateTime",
+                "value": "TODAY"
+              },
+              {
+                "condition": "AND",
+                "filterType": "custom",
+                "key": "metadataDomain",
+                "operator": "LIKE",
+                "type": "Nullable(String)",
+                "value": "'%${domain_name}%'"
+              }
+            ],
+            "groupBy": [
+              "locationID",
+              "longitude",
+              "latitude",
+              "cloud"
+            ],
+            "limit": 1000,
+            "meta": {},
+            "mode": "aggregate",
+            "orderBy": [],
+            "queryType": "table",
+            "table": "logs"
+          },
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "avg",
+                  "alias": "AvgResponseTime",
+                  "column": "dns"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "latitude",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "longitude",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "cloud",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "locationID",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "apicontext",
+              "filters": [
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "startTime",
+                  "operator": "WITH IN DASHBOARD TIME RANGE",
+                  "type": "DateTime",
+                  "value": "TODAY"
+                },
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "metadataDomain",
+                  "operator": "LIKE",
+                  "type": "Nullable(String)",
+                  "value": "'%${domain_name}%'"
+                }
+              ],
+              "groupBy": [
+                "locationID",
+                "longitude",
+                "latitude",
+                "cloud"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "logs"
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  ${ipAddr_latitude} AS Latitude, \n  ${ipAddr_longitude} AS Longitude, \n  cloud, \n  locationID, \n  ${avg_dns_lookup_time} as AvgResponseTime \nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})  \n  AND $__adHocFilter()\n  AND Latitude != '0'\n  AND Longitude != '0'\nGROUP BY locationID, Longitude, Latitude, cloud\nLIMIT 500\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=DNS around the world; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS around the world",
+      "type": "geomap"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the Average time for Connect, Proccesing and TlsHandShake.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 0
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 100
+              },
+              {
+                "color": "#EF843C",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "stdDev"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n    toStartOfInterval(${timestamp}, INTERVAL 300 SECOND) AS time, \n    ${avg_tcp_connect_time} AS avg_connect, \n    ${avg_processing_time} AS avg_processing, \n    ${avg_tls_handshake_time} AS avg_tls_handshake\nFROM ${table}\nWHERE \n    ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n    AND $__adHocFilter()\nGROUP BY time\nORDER BY time ASC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Latency Breakdown by Metric; du=${__user.login}'",
+          "refId": "B"
+        }
+      ],
+      "title": "Latency Breakdown by Metric",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the total requests for each Metadata Domain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  metadataDomain,\n  COUNT() as Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top Domains; du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Domains",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the total requests and tlsHandshake average time for each Region.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "id": 4,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "error_rate",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "error_rate",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Error Rate",
+            "tooltip": true,
+            "type": "markers"
+          },
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "avg_tls_handshake",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "avg_tls_handshake",
+                  "fixed": 5,
+                  "max": 15,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Avg TLS Handshake",
+            "tooltip": true,
+            "type": "markers"
+          },
+          {
+            "config": {
+              "blur": 15,
+              "radius": 5,
+              "weight": {
+                "field": "failed_requests",
+                "fixed": 1,
+                "max": 1,
+                "min": 0
+              }
+            },
+            "filterData": {
+              "id": "byRefId",
+              "options": "A"
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Failed Requests",
+            "opacity": 0.4,
+            "tooltip": true,
+            "type": "heatmap"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n    ${ipAddr_city} as region,\n    ${ipAddr_latitude} AS latitude, \n    ${ipAddr_longitude} AS longitude, \n    ${avg_tls_handshake_time} AS avg_tls_handshake,\n    ${failed_requests} AS failed_requests,\n    ${cnt_all} AS total_requests,\n    ${error_rate} AS error_rate\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(region)\nGROUP BY region, latitude, longitude\nORDER BY region\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Combined Regional SLA Heatmap; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Combined Regional SLA Heatmap",
+      "type": "geomap"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the total requests for each Context Category.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 15,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 1,
+        "fullHighlight": true,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Total",
+          "sortDesc": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "percent",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "time",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "hide": false,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "timeseries",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Categories",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the TlsHandshake average time for each Region and Cloud",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "dark-green",
+                "value": 65
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 100
+              },
+              {
+                "color": "dark-blue",
+                "value": 150
+              },
+              {
+                "color": "#EAB839",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 250
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 3,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "avg_tls_handshake",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.3,
+                "rotation": {
+                  "field": "avg_tls_handshake",
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "clamped"
+                },
+                "size": {
+                  "field": "avg_tls_handshake",
+                  "fixed": 5,
+                  "max": 40,
+                  "min": 2
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "symbolAlign": {
+                  "horizontal": "center",
+                  "vertical": "center"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "filterData": {
+              "id": "byRefId",
+              "options": "A"
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "ms",
+            "tooltip": true,
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": false,
+          "id": "fit",
+          "lastOnly": false,
+          "lat": 0,
+          "layer": "ms",
+          "lon": 0,
+          "zoom": 15
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "timeseries",
+          "rawSql": "SELECT \n    ${ipAddr_city} as region, \n    ${ipAddr_latitude} AS latitude,\n    ${ipAddr_longitude} AS longitude,\n    cloud,\n    ${avg_tls_handshake_time} AS avg_tls_handshake\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(region)\nGROUP BY region, latitude, longitude, cloud\nORDER BY avg_tls_handshake DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Regional TLS Handshake Performance; du=${__user.login}'",
+          "refId": "A"
+        }
+      ],
+      "title": "Regional TLS Handshake Performance",
+      "transparent": true,
+      "type": "geomap"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the total requests for each Status Code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 90
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Total",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Status Codes",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "hydrolix-hydrolix-datasource",
+        "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+      },
+      "description": "Shows the total requests for each Cloud and Continent.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cloud"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 203
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 90
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT \n  cloud as Cloud, \n  ${ipAddr_continent} as Continent,\n  ${cnt_all} as Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(Continent)\nGROUP BY Cloud, Continent\nORDER BY Total DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top location IDs; du=${__user.login}'\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Top location IDs",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [
+    "v1.0",
+    "Required tables: apicontext_sampled_day"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "definition": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+        "hide": 2,
+        "name": "table",
+        "options": [],
+        "query": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "name": "timestamp",
+        "query": "${VAR_TIMESTAMP}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TIMESTAMP}",
+          "text": "${VAR_TIMESTAMP}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TIMESTAMP}",
+            "text": "${VAR_TIMESTAMP}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "baseFilters": [],
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "${DS_HYDROLIX-HYDROLIX-DATASOURCE}"
+        },
+        "filters": [],
+        "name": "filter",
+        "type": "adhoc"
+      },
+      {
+        "current": {},
+        "definition": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+        "hide": 2,
+        "name": "duration",
+        "options": [],
+        "query": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "name": "apicontext_sampled_day",
+        "query": "__APICONTEXT_SAMPLED_DAY__",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "__APICONTEXT_SAMPLED_DAY__",
+          "text": "__APICONTEXT_SAMPLED_DAY__",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "__APICONTEXT_SAMPLED_DAY__",
+            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "name": "logs",
+        "query": "__PROJECT_NAME__.__TABLE_NAME__",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "__PROJECT_NAME__.__TABLE_NAME__",
+          "text": "__PROJECT_NAME__.__TABLE_NAME__",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+        "hide": 2,
+        "name": "cnt_all",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+        "hide": 2,
+        "name": "avg_responseTime",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+        "hide": 2,
+        "name": "avg_dns_lookup_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+        "hide": 2,
+        "name": "avg_tcp_connect_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+        "hide": 2,
+        "name": "avg_tls_handshake_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+        "hide": 2,
+        "name": "avg_processing_time",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'sumIf(1, contextCategory = \\'FAIL\\')',\n'failed_requests'\n)",
+        "hide": 2,
+        "name": "failed_requests",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'sumIf(1, contextCategory = \\'FAIL\\')',\n'failed_requests'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'(sumIf (1, contextCategory = \\'FAIL\\')/ count()) * 100',\n'error_rate'\n)",
+        "hide": 2,
+        "name": "error_rate",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'(sumIf (1, contextCategory = \\'FAIL\\')/ count()) * 100',\n'error_rate'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', ipAddr)'\n)",
+        "hide": 2,
+        "name": "ipAddr_latitude",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', ipAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'longitude',\n'akamai_geo(\\'longitude\\', ipAddr)'\n)",
+        "hide": 2,
+        "name": "ipAddr_longitude",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'longitude',\n'akamai_geo(\\'longitude\\', ipAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT 'continent'",
+        "hide": 2,
+        "name": "ipAddr_continent",
+        "options": [],
+        "query": "SELECT 'continent'",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(ipAddr)'\n)",
+        "hide": 2,
+        "name": "ipAddr_city",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(ipAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(targetIPAddr)'\n)",
+        "hide": 2,
+        "name": "targetIPAddr_city",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(targetIPAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', targetIPAddr)'\n)",
+        "hide": 2,
+        "name": "targetIPAddr_latitude",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', targetIPAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'longitude\\', targetIPAddr)'\n)",
+        "hide": 2,
+        "name": "targetIPAddr_longitude",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'longitude\\', targetIPAddr)'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(dns)',\n'sum_dns'\n)",
+        "hide": 2,
+        "name": "sum_dns",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(dns)',\n'sum_dns'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(connect)',\n'sum_connect'\n)",
+        "hide": 2,
+        "name": "sum_connect",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(connect)',\n'sum_connect'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(tlsHandshake)',\n'sum_tlsHandshake'\n)",
+        "hide": 2,
+        "name": "sum_tlsHandshake",
+        "options": [],
+        "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(tlsHandshake)',\n'sum_tlsHandshake'\n)",
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {
+    "nowDelay": "1m",
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Network Monitoring Dashboard (Synthetics)",
+  "version": 14,
+  "weekStart": ""
+}

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/resources.gfo.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/resources.gfo.yaml
@@ -12,7 +12,7 @@ dashboards:
     inputs:
       DS_HYDROLIX-HYDROLIX-DATASOURCE: hdx-hydrolix-datasource
       VAR_TIMESTAMP: startTime
-      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__
+      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__
       VAR_LOGS: akamai.apicontext
       VAR_SIEM: __PROJECT_NAME__.__SIEM_TABLE_NAME__
   hdx-api-observability:
@@ -22,6 +22,6 @@ dashboards:
     inputs:
       DS_HYDROLIX-HYDROLIX-DATASOURCE: hdx-hydrolix-datasource
       VAR_TIMESTAMP: startTime
-      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__
+      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__
       VAR_LOGS: akamai.apicontext
       VAR_SIEM: __PROJECT_NAME__.__SIEM_TABLE_NAME__

--- a/portables/trafficpeak/apicontext/1.0.0/grafana/resources.gfo.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/grafana/resources.gfo.yaml
@@ -1,0 +1,27 @@
+folders:
+  hdx-main-folder:
+    name: TrafficPeak Certified Reference Dashboards
+    children:
+      hdx-security-folder:
+        name: Security
+dashboards:
+  hdx-network-monitoring-dashboard-synthetics:
+    dashboard:
+      __extend__: dashboards/network_monitoring_dashboard_synthetics.json
+    folderUid: hdx-security-folder
+    inputs:
+      DS_HYDROLIX-HYDROLIX-DATASOURCE: hdx-hydrolix-datasource
+      VAR_TIMESTAMP: startTime
+      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__
+      VAR_LOGS: akamai.apicontext
+      VAR_SIEM: __PROJECT_NAME__.__SIEM_TABLE_NAME__
+  hdx-api-observability:
+    dashboard:
+      __extend__: dashboards/api_observability.json
+    folderUid: hdx-security-folder
+    inputs:
+      DS_HYDROLIX-HYDROLIX-DATASOURCE: hdx-hydrolix-datasource
+      VAR_TIMESTAMP: startTime
+      VAR_APICONTEXT_SAMPLED_DAY: __PROJECT_NAME__.__APICONTEXT_SAMPLED_DAY__
+      VAR_LOGS: akamai.apicontext
+      VAR_SIEM: __PROJECT_NAME__.__SIEM_TABLE_NAME__

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/resources.hdp.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/resources.hdp.yaml
@@ -1,0 +1,15 @@
+tables:
+  apicontext:
+    __extend__: tables/table_apicontext.yaml
+transforms:
+  apicontext:
+    default_context_logs:
+      __extend__: transforms/default_context_logs.json
+      settings:
+        sql_transform:
+          __extend__: transforms/default_context_logs_select.sql
+        sample_data:
+          __extend__: transforms/default_context_logs_sample_data.json
+summary_tables:
+  apicontext_sampled_day:
+    __extend__: tables/apicontext_sampled_day.yaml

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/apicontext_sampled_day.sql
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/apicontext_sampled_day.sql
@@ -1,0 +1,75 @@
+SELECT
+  toStartOfDay (startTime) AS startTime,
+  httpCode,
+  contextCategory,
+  locationID,
+  IF(
+    cityHash64 (metadataDomain, startTime, resultID) % 100 < 10,
+    metadataDomain,
+    '~~~SAMPLED_OUT~~~'
+  ) AS metadataDomain,
+  cloud,
+  targetCloud,
+  IF(
+    cityHash64 (ipAddr, startTime, resultID) % 100 < 10,
+    ipAddr,
+    '~~~SAMPLED_OUT~~~'
+  ) AS ipAddr,
+  IF(
+    cityHash64 (targetIPAddr, startTime, resultID) % 100 < 10,
+    targetIPAddr,
+    '~~~SAMPLED_OUT~~~'
+  ) AS targetIPAddr,
+  city,
+  continent,
+  IF(
+    cityHash64 (callURL, startTime, resultID) % 100 < 10,
+    callURL,
+    '~~~SAMPLED_OUT~~~'
+  ) AS callURL,
+  IF(
+    cityHash64 (callID, startTime, resultID) % 100 < 10,
+    callID,
+    '~~~SAMPLED_OUT~~~'
+  ) AS callID,
+  IF(
+    cityHash64 (resultID, startTime) % 100 < 1,
+    resultID,
+    '~~~SAMPLED_OUT~~~'
+  ) AS resultID,
+  IF(
+    cityHash64 (apiCreationTime, startTime, resultID) % 100 < 10,
+    apiCreationTime,
+    null
+  ) AS apiCreationTime,
+  COUNT(*) AS cnt_all,
+  AVG(responseTime) AS avg_responseTime,
+  AVG(dns) AS avg_dns_lookup_time,
+  AVG(connect) AS avg_tcp_connect_time,
+  AVG(tlsHandshake) AS avg_tls_handshake_time,
+  AVG(upload) AS avg_upload_time,
+  AVG(processing) AS avg_processing_time,
+  AVG(download) AS avg_download_time,
+  SUM(dns) AS sum_dns,
+  SUM(connect) AS sum_connect,
+  SUM(tlsHandshake) AS sum_tlsHandshake,
+  sumIf (1, contextCategory = 'FAIL') AS failed_requests,
+  (failed_requests / cnt_all) * 100 AS error_rate
+FROM
+  akamai.apicontext
+GROUP BY
+  startTime,
+  httpCode,
+  locationID,
+  contextCategory,
+  metadataDomain,
+  cloud,
+  targetCloud,
+  city,
+  continent,
+  ipAddr,
+  targetIPAddr,
+  callURL,
+  callID,
+  resultID,
+  apiCreationTime SETTINGS hdx_primary_key = 'startTime'

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/apicontext_sampled_day.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/apicontext_sampled_day.yaml
@@ -1,0 +1,6 @@
+__extend__: ../../../../../../hydrolix/_defaults/table_summary_base_defaults.yaml
+description: apicontext_sampled_day
+settings:
+  summary:
+    sql:
+      __extend__: apicontext_sampled_day.sql

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/table_apicontext.yaml
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/tables/table_apicontext.yaml
@@ -1,0 +1,3 @@
+__extend__: ../../../../../../hydrolix/_defaults/table_defaults.yaml
+description: TRAFFICPEAK Apicontext integration bundle
+type: turbine

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs.json
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs.json
@@ -1,0 +1,1473 @@
+{
+  "name": "default_context_logs",
+  "description": "",
+  "settings": {
+    "is_default": true,
+    "rate_limit": null,
+    "null_values": [],
+    "data_mirroring_target": null,
+    "output_columns": [
+      {
+        "name": "apiCreationTime",
+        "datatype": {
+          "type": "datetime",
+          "index": true,
+          "primary": false,
+          "format": "2006-01-02T15:04:05.999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/created"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "callID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataDescription",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/description"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataDomain",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/domain"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataTagsString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/tags"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "metadataTags",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaOrg",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/organization"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaTagsString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/tags"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "projectMetaTags",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "callURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextCategory",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/category"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextDescription",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextDescriptionText",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description_text"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextLastUpdate",
+        "datatype": {
+          "type": "datetime",
+          "index": true,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/last_update"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextOwnersString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/owners"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextOwners",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextReferencesString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/references"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextReferences",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextTitle",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/title"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextViewedString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/viewed_by"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextViewed",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextResultCategory",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_category"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextResultStreak",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_streak"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "httpCode",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_code"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "dnsLookupMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_lookup_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "sslHandshakeMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/ssl_handshake_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "uploadMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/upload_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "processingMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/processing_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "downloadMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/download_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "httpReason",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_reason"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "locationID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "responseSize",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_size"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "responseTime",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_time"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "result",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultClass",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_class"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowId",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowResultId",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowResultUrl",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowUrl",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "startTime",
+        "datatype": {
+          "type": "datetime",
+          "index": false,
+          "primary": true,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/start_time"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetIPAddr",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/ip_addr"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCloud",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cloud"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCity",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/city"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetRegion",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/region"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCountry",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/country"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetContinent",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/continent"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetLatitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/latitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetLongitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/longitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetNetwork",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/network"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCdn",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cdn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetAsn",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/asn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "city",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/city"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "cloud",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/cloud"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "ipAddr",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/ip_addr"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "region",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/region"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "country",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/country"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "continent",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/continent"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "latitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/latitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "longitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/longitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "dns",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/dns"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "connect",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/connect"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "tlsHandshake",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/tls_handshake"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "upload",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/upload"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "processing",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/processing"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "download",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/download"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "total",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/total"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "aRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/a"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "nsRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/ns"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "cnameRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/cname"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "otelTraceparentID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/otel_traceparent_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainAgeInDays",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/age_in_days"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainDNSProvider",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/dns_provider"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainFQDN",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/fqdn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainRegistrar",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/registrar"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainTLD",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/tld"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "tlsCertificates",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": true
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/tls_certificates"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "unknown",
+        "datatype": {
+          "type": "map",
+          "index": true,
+          "catch_all": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": true
+            },
+            {
+              "type": "string",
+              "index": true
+            }
+          ],
+          "source": null,
+          "suppress": true
+        }
+      }
+    ],
+    "compression": "",
+    "wurfl": null,
+    "format_details": {
+      "flattening": {
+        "depth": null,
+        "active": false,
+        "map_flattening_strategy": {
+          "left": "",
+          "right": ""
+        },
+        "slice_flattening_strategy": {
+          "left": "",
+          "right": ""
+        }
+      }
+    }
+  },
+  "type": "json"
+}

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs.json
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs.json
@@ -1,1463 +1,12 @@
 {
-  "name": "default_context_logs",
   "description": "",
+  "name": "default_context_logs",
   "settings": {
-    "is_default": true,
-    "rate_limit": null,
-    "null_values": [],
-    "data_mirroring_target": null,
-    "output_columns": [
-      {
-        "name": "apiCreationTime",
-        "datatype": {
-          "type": "datetime",
-          "index": true,
-          "primary": false,
-          "format": "2006-01-02T15:04:05.999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/created"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "callID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataDescription",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/description"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataDomain",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/domain"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataTagsString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/tags"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "metadataTags",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaOrg",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/organization"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaTagsString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/tags"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "projectMetaTags",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "callURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextCategory",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/category"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextDescription",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/description"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextDescriptionText",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/description_text"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextLastUpdate",
-        "datatype": {
-          "type": "datetime",
-          "index": true,
-          "format": "2006-01-02T15:04:05.999999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/last_update"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextOwnersString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/owners"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextOwners",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextReferencesString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/references"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextReferences",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextTitle",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/title"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextViewedString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/viewed_by"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextViewed",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextResultCategory",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_result_category"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextResultStreak",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_result_streak"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "httpCode",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/http_code"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "dnsLookupMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/dns_lookup_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "sslHandshakeMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/ssl_handshake_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "uploadMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/upload_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "processingMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/processing_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "downloadMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/download_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "httpReason",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/http_reason"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "locationID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "responseSize",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/response_size"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "responseTime",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/response_time"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "result",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultClass",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_class"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowId",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowResultId",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_result_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowResultUrl",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_result_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowUrl",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "startTime",
-        "datatype": {
-          "type": "datetime",
-          "index": false,
-          "primary": true,
-          "format": "2006-01-02T15:04:05.999999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/start_time"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetIPAddr",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/ip_addr"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCloud",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/cloud"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCity",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/city"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetRegion",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/region"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCountry",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/country"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetContinent",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/continent"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetLatitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/latitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetLongitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/longitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetNetwork",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/network"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCdn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/cdn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetAsn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/asn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "city",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/city"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "cloud",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/cloud"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "ipAddr",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/ip_addr"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "region",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/region"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "country",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/country"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "continent",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/continent"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "latitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/latitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "longitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/longitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "dns",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/dns"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "connect",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/connect"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "tlsHandshake",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/tls_handshake"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "upload",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/upload"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "processing",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/processing"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "download",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/download"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "total",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/total"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "aRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/a"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "nsRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/ns"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "cnameRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/cname"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "otelTraceparentID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/otel_traceparent_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainAgeInDays",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/age_in_days"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainDNSProvider",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/dns_provider"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainFQDN",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/fqdn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainRegistrar",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/registrar"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainTLD",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/tld"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "tlsCertificates",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/tls_certificates"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "unknown",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "catch_all": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": null,
-          "suppress": true
-        }
-      }
-    ],
     "compression": "",
-    "wurfl": null,
     "format_details": {
       "flattening": {
-        "depth": null,
         "active": false,
+        "depth": null,
         "map_flattening_strategy": {
           "left": "",
           "right": ""
@@ -1467,7 +16,1457 @@
           "right": ""
         }
       }
-    }
+    },
+    "is_default": true,
+    "null_values": [],
+    "output_columns": [
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999Z",
+          "index": true,
+          "primary": false,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/created"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "apiCreationTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "callID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/description"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataDescription"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/domain"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataDomain"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/tags"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "metadataTagsString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "metadataTags"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/organization"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaOrg"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/tags"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "projectMetaTagsString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "projectMetaTags"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "callURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/category"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextCategory"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextDescription"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description_text"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextDescriptionText"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "index": true,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/last_update"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "contextLastUpdate"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/owners"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextOwnersString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextOwners"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/references"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextReferencesString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextReferences"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/title"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextTitle"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/viewed_by"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextViewedString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextViewed"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_category"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextResultCategory"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_streak"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "contextResultStreak"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_code"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "httpCode"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_lookup_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "dnsLookupMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/ssl_handshake_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "sslHandshakeMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/upload_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "uploadMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/processing_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "processingMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/download_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "downloadMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_reason"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "httpReason"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "locationID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_size"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "responseSize"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_time"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "responseTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "result"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_class"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultClass"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowId"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowResultId"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowResultUrl"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowUrl"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "index": false,
+          "primary": true,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/start_time"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "startTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/ip_addr"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetIPAddr"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cloud"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCloud"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/city"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCity"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/region"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetRegion"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/country"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCountry"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/continent"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetContinent"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/latitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "targetLatitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/longitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "targetLongitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/network"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetNetwork"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cdn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCdn"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/asn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetAsn"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/city"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "city"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/cloud"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "cloud"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/ip_addr"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ipAddr"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/region"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "region"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/country"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "country"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/continent"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "continent"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/latitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "latitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/longitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "longitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/dns"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "dns"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/connect"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "connect"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/tls_handshake"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "tlsHandshake"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/upload"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "upload"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/processing"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "processing"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/download"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "download"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/total"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "total"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/a"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "aRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/ns"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "nsRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/cname"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "cnameRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/otel_traceparent_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "otelTraceparentID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/age_in_days"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "domainAgeInDays"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/dns_provider"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainDNSProvider"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/fqdn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainFQDN"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/registrar"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainRegistrar"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/tld"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainTLD"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": true,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/tls_certificates"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "tlsCertificates"
+      },
+      {
+        "datatype": {
+          "catch_all": true,
+          "default": null,
+          "elements": [
+            {
+              "index": true,
+              "type": "string"
+            },
+            {
+              "index": true,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": null,
+          "suppress": true,
+          "type": "map"
+        },
+        "name": "unknown"
+      }
+    ],
+    "rate_limit": null,
+    "wurfl": null
   },
   "type": "json"
 }

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_sample_data.json
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_sample_data.json
@@ -1,73 +1,73 @@
 {
-  "result": "HTTP_CLIENT_ERROR",
   "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+  "call_meta": {
+    "description": "Auto-generated API Call",
+    "domain": "api.sampledata.co.uk",
+    "name": "Example HTTP POST Call",
+    "tags": [
+      "api_type:update",
+      "sector:telecommunications"
+    ]
+  },
+  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
   "context": {
     "_notification": {
-      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "category": "WARNING",
+      "created": "2020-11-27T10:44:19.284152Z",
+      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n",
+      "last_update": "2025-11-28T10:44:19.427550Z",
       "owners": [
         "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
         "public_settings"
-      ],
-      "created": "2019-06-05T17:11:36.444708Z",
-      "category": "WARNING",
-      "viewed_by": [
-        "Martin"
       ],
       "references": [
         "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
         "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
       ],
-      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
-      "last_update": "2024-06-05T17:11:36.588106Z",
-      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "viewed_by": [
+        "Martin"
+      ]
     },
-    "_result_streak": 1,
-    "_result_category": "WARNING"
+    "_result_category": "WARNING",
+    "_result_streak": 1
   },
-  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
-  "call_meta": {
-    "name": "Example HTTP POST Call",
-    "tags": [
-      "api_type:update",
-      "sector:telecommunications"
-    ],
-    "domain": "api.sampledata.co.uk",
-    "description": "Auto-generated API Call"
-  },
-  "http_code": 418,
-  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
-  "upload_ms": 333,
-  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
-  "start_time": "2024-10-07T06:27:17.160556Z",
-  "download_ms": 555,
-  "http_reason": "I'M A TEAPOT",
-  "location_id": "development",
-  "timing_data": {
-    "dns": 2,
-    "upload": 0,
-    "connect": 1,
-    "download": 13522,
-    "processing": 118,
-    "tls_handshake": 234
-  },
-  "workflow_id": null,
-  "result_class": "WARNING",
-  "workflow_url": null,
   "dns_lookup_ms": 111,
+  "download_ms": 555,
+  "http_code": 418,
+  "http_reason": "I'M A TEAPOT",
   "location_data": {
     "city": "london",
     "cloud": "Akamai",
-    "region": "eng",
+    "continent": "EU",
     "country": "GB",
     "ip_addr": "169.254.169.126",
     "latitude": null,
-    "continent": "EU",
-    "longitude": null
+    "longitude": null,
+    "region": "eng"
   },
+  "location_id": "development",
   "processing_ms": 4479,
   "response_size": 135,
   "response_time": 56,
+  "result": "HTTP_CLIENT_ERROR",
+  "result_class": "WARNING",
+  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
   "ssl_handshake_ms": 222,
+  "start_time": "2026-04-01T00:00:00.000000Z",
+  "timing_data": {
+    "connect": 1,
+    "dns": 2,
+    "download": 13522,
+    "processing": 118,
+    "tls_handshake": 234,
+    "upload": 0
+  },
+  "upload_ms": 333,
+  "workflow_id": null,
   "workflow_result_id": null,
-  "workflow_result_url": null
+  "workflow_result_url": null,
+  "workflow_url": null
 }

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_sample_data.json
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_sample_data.json
@@ -1,0 +1,73 @@
+{
+  "result": "HTTP_CLIENT_ERROR",
+  "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+  "context": {
+    "_notification": {
+      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "owners": [
+        "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
+        "public_settings"
+      ],
+      "created": "2019-06-05T17:11:36.444708Z",
+      "category": "WARNING",
+      "viewed_by": [
+        "Martin"
+      ],
+      "references": [
+        "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+        "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
+      ],
+      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+      "last_update": "2024-06-05T17:11:36.588106Z",
+      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+    },
+    "_result_streak": 1,
+    "_result_category": "WARNING"
+  },
+  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
+  "call_meta": {
+    "name": "Example HTTP POST Call",
+    "tags": [
+      "api_type:update",
+      "sector:telecommunications"
+    ],
+    "domain": "api.sampledata.co.uk",
+    "description": "Auto-generated API Call"
+  },
+  "http_code": 418,
+  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+  "upload_ms": 333,
+  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
+  "start_time": "2024-10-07T06:27:17.160556Z",
+  "download_ms": 555,
+  "http_reason": "I'M A TEAPOT",
+  "location_id": "development",
+  "timing_data": {
+    "dns": 2,
+    "upload": 0,
+    "connect": 1,
+    "download": 13522,
+    "processing": 118,
+    "tls_handshake": 234
+  },
+  "workflow_id": null,
+  "result_class": "WARNING",
+  "workflow_url": null,
+  "dns_lookup_ms": 111,
+  "location_data": {
+    "city": "london",
+    "cloud": "Akamai",
+    "region": "eng",
+    "country": "GB",
+    "ip_addr": "169.254.169.126",
+    "latitude": null,
+    "continent": "EU",
+    "longitude": null
+  },
+  "processing_ms": 4479,
+  "response_size": 135,
+  "response_time": 56,
+  "ssl_handshake_ms": 222,
+  "workflow_result_id": null,
+  "workflow_result_url": null
+}

--- a/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_select.sql
+++ b/portables/trafficpeak/apicontext/1.0.0/hydrolix/transforms/default_context_logs_select.sql
@@ -1,0 +1,12 @@
+SELECT 
+arrayMap(x -> REPLACE(x, '\"', ''), 
+JSONExtractArrayRaw(assumeNotNull(metadataTagsString))) AS metadataTags,
+arrayMap(x -> REPLACE(x, '\"', ''), 
+JSONExtractArrayRaw(assumeNotNull(projectMetaTagsString))) AS projectMetaTags,
+arrayMap(x -> REPLACE(x, '\"', ''), 
+JSONExtractArrayRaw(assumeNotNull(contextOwnersString))) AS contextOwners,
+arrayMap(x -> REPLACE(x, '\"', ''), 
+JSONExtractArrayRaw(assumeNotNull(contextReferencesString))) AS contextReferences,
+arrayMap(x -> REPLACE(x, '\"', ''), 
+JSONExtractArrayRaw(assumeNotNull(contextViewedString))) AS contextViewed,
+* FROM {STREAM}

--- a/trafficpeak/apicontext/bundle-config.json
+++ b/trafficpeak/apicontext/bundle-config.json
@@ -1,0 +1,5 @@
+{
+  "data_category": "security",
+  "table_name": "apicontext",
+  "version": "1.0.0"
+}

--- a/trafficpeak/apicontext/bundle.json
+++ b/trafficpeak/apicontext/bundle.json
@@ -1,0 +1,67 @@
+{
+  "base_url": "https://github.com/hydrolix/integration-deployment-templates/blob/main/trafficpeak/apicontext",
+  "beta": true,
+  "dashboard": {
+    "path": "dashboards/api-observability.json",
+    "project_var": "__PROJECT_NAME__"
+  },
+  "dependencies": {
+    "hydrolix": {
+      "required_dictionaries": [],
+      "required_functions": [],
+      "shared_dictionaries": [],
+      "shared_functions": []
+    }
+  },
+  "metadata": {
+    "channel_type": "3rdParty",
+    "description": "Trafficpeak Apicontext Integration",
+    "maintainer": "Hydrolix Team <team@hydrolix.io>",
+    "version": "1.0.0"
+  },
+  "method": "http_streaming",
+  "name": "trafficpeak_apicontext",
+  "other_dashboards": [
+    {
+      "path": "dashboards/network-monitoring-dashboard-synthetics.json",
+      "project_var": "__PROJECT_NAME__"
+    }
+  ],
+  "solution": true,
+  "source": "trafficpeak",
+  "summary_tables": [
+    {
+      "dashboard_var": "__SUMMARY_TABLE_NAME_1__",
+      "name": "apicontext_sampled_day",
+      "parent_table_name": "apicontext",
+      "sql": {
+        "path": "summaries/apicontext_sampled_day.sql"
+      }
+    }
+  ],
+  "tables": [
+    {
+      "dashboard_var": "__TABLE_NAME__",
+      "name": "apicontext",
+      "transforms": [
+        {
+          "path": "transformations/transform.json",
+          "sample": "transformations/sample_data.json",
+          "method": "http_streaming"
+        }
+      ]
+    }
+  ],
+  "ui": {
+    "data_category": "security",
+    "method": {
+      "full_title": "Http Streaming",
+      "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
+    },
+    "primary_url": "https://docs.hydrolix.io/docs/apicontext-integration",
+    "source": {
+      "full_title": "Trafficpeak Apicontext",
+      "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"
+    }
+  }
+}

--- a/trafficpeak/apicontext/dashboards/api-observability.json
+++ b/trafficpeak/apicontext/dashboards/api-observability.json
@@ -1,0 +1,1821 @@
+{
+  "dashboard": {
+    "__elements": {
+      "model": {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        }
+      }
+    },
+    "__requires": [
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "12.0.2"
+      },
+      {
+        "type": "datasource",
+        "id": "hydrolix-hydrolix-datasource",
+        "name": "Hydrolix",
+        "version": "0.6.0"
+      },
+      {
+        "type": "panel",
+        "id": "piechart",
+        "name": "Pie chart",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "text",
+        "name": "Text",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "timeseries",
+        "name": "Time series",
+        "version": ""
+      }
+    ],
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 19,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "Reports on network times, number of requests by categories, status codes, and location ID's.",
+          "mode": "markdown"
+        },
+        "pluginVersion": "12.0.2",
+        "title": "API Observability",
+        "type": "text"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 2
+        },
+        "id": 18,
+        "panels": [],
+        "title": "All data within this dashboard is from public endpoints of various domains",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Number of request group by HTTP Status Code.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 3
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [
+              "sum"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Total",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP codes",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Number of requests per Context Category.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 3
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "sum"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Total",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "hoverProximity": 1,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Categories",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Average Response Time Along Time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 14
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average response time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Total Count and Percentage per Localtion ID.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 14
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "values": [
+              "percent",
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  locationID,\n  ${cnt_all}\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY locationID\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top location IDs; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Top location IDs",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Average DNS Time Along Time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 25
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average DNS lookup time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the Connect average time along time.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 25
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average TCP connect time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the average time for tlsHandshake.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 36
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average SSL handshake time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of tlsHandshake, connect, and dns times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 36
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Total networking time (DNS + TCP + SSL)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of connect, tlsHandshake, and upload times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 47
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "It shows the sum of the averages of tlsHandshake, connect, and dns.",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of dns, connect, tlsHandshake, and upload times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 47
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Total time until first byte (including networking time)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of connect, tlsHandshake, and upload times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 58
+        },
+        "id": 15,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Total time until first byte (excluding DNS)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of connect, tlsHandshake,upload, and processing times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 58
+        },
+        "id": 16,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Total time (excluding DNS)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of dns, connect, tlsHandshake,  and download times.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 69
+        },
+        "id": 17,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Total time (including DNS)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 41,
+    "tags": [
+      "v1.0",
+      "Required tables: apicontext_sampled_day"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "definition": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+          "hide": 2,
+          "name": "table",
+          "options": [],
+          "query": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+          "refresh": 1,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "hide": 2,
+          "name": "timestamp",
+          "query": "startTime",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "selected": false,
+            "text": "startTime",
+            "value": "startTime"
+          },
+          "options": [
+            {
+              "selected": false,
+              "text": "startTime",
+              "value": "startTime"
+            }
+          ]
+        },
+        {
+          "baseFilters": [],
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "__DATASOURCE__"
+          },
+          "filters": [],
+          "name": "filter",
+          "type": "adhoc"
+        },
+        {
+          "current": {},
+          "definition": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+          "hide": 2,
+          "name": "duration",
+          "options": [],
+          "query": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "hide": 2,
+          "name": "apicontext_sampled_day",
+          "query": "__APICONTEXT_SAMPLED_DAY__",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "value": "__APICONTEXT_SAMPLED_DAY__",
+            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "selected": false
+          },
+          "options": [
+            {
+              "value": "__APICONTEXT_SAMPLED_DAY__",
+              "text": "__APICONTEXT_SAMPLED_DAY__",
+              "selected": false
+            }
+          ]
+        },
+        {
+          "hide": 2,
+          "name": "logs",
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false
+          },
+          "options": [
+            {
+              "value": "__PROJECT_NAME__.__TABLE_NAME__",
+              "text": "__PROJECT_NAME__.__TABLE_NAME__",
+              "selected": false
+            }
+          ]
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+          "hide": 2,
+          "name": "cnt_all",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+          "hide": 2,
+          "name": "avg_responseTime",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+          "hide": 2,
+          "name": "avg_dns_lookup_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+          "hide": 2,
+          "name": "avg_tcp_connect_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+          "hide": 2,
+          "name": "avg_tls_handshake_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(upload)',\n'avg_upload_time'\n)",
+          "hide": 2,
+          "name": "avg_upload_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(upload)',\n'avg_upload_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+          "hide": 2,
+          "name": "avg_processing_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(download)',\n'avg_download_time'\n)",
+          "hide": 2,
+          "name": "avg_download_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(download)',\n'avg_download_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
+          },
+          "hide": 2,
+          "name": "raw_table",
+          "options": [
+            {
+              "selected": false,
+              "text": "__PROJECT_NAME__.__TABLE_NAME__",
+              "value": "__PROJECT_NAME__.__TABLE_NAME__"
+            }
+          ],
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30d",
+      "to": "now"
+    },
+    "timepicker": {
+      "nowDelay": "1m",
+      "refresh_intervals": [
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "utc",
+    "title": "API observability",
+    "uid": "__DASHBOARD_UUID__",
+    "version": 9,
+    "weekStart": ""
+  }
+}

--- a/trafficpeak/apicontext/dashboards/api-observability.json
+++ b/trafficpeak/apicontext/dashboards/api-observability.json
@@ -1652,18 +1652,18 @@
         {
           "hide": 2,
           "name": "apicontext_sampled_day",
-          "query": "__APICONTEXT_SAMPLED_DAY__",
+          "query": "__SUMMARY_TABLE_NAME_1__",
           "skipUrlSync": true,
           "type": "constant",
           "current": {
-            "value": "__APICONTEXT_SAMPLED_DAY__",
-            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "value": "__SUMMARY_TABLE_NAME_1__",
+            "text": "__SUMMARY_TABLE_NAME_1__",
             "selected": false
           },
           "options": [
             {
-              "value": "__APICONTEXT_SAMPLED_DAY__",
-              "text": "__APICONTEXT_SAMPLED_DAY__",
+              "value": "__SUMMARY_TABLE_NAME_1__",
+              "text": "__SUMMARY_TABLE_NAME_1__",
               "selected": false
             }
           ]

--- a/trafficpeak/apicontext/dashboards/api-observability.json
+++ b/trafficpeak/apicontext/dashboards/api-observability.json
@@ -10,33 +10,33 @@
     },
     "__requires": [
       {
-        "type": "grafana",
         "id": "grafana",
         "name": "Grafana",
+        "type": "grafana",
         "version": "12.0.2"
       },
       {
-        "type": "datasource",
         "id": "hydrolix-hydrolix-datasource",
         "name": "Hydrolix",
+        "type": "datasource",
         "version": "0.6.0"
       },
       {
-        "type": "panel",
         "id": "piechart",
         "name": "Pie chart",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "text",
         "name": "Text",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "timeseries",
         "name": "Time series",
+        "type": "panel",
         "version": ""
       }
     ],
@@ -201,7 +201,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(httpCode),\n  ${cnt_all} as http\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, httpCode\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=HTTP codes; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -322,7 +322,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(contextCategory),\n${cnt_all} AS Category\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -439,7 +439,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_responseTime} AS \"Response Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -638,7 +638,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} AS \"DNS Lookup Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -755,7 +755,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} AS \"TCP connect Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -872,7 +872,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} AS \"SSL handshake Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -989,7 +989,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1106,7 +1106,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking time excluding DNS; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1223,7 +1223,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (including networking time); du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1340,7 +1340,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time until first byte (excluding DNS); du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1457,7 +1457,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_upload_time} + ${avg_processing_time} + ${avg_download_time} AS \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (excluding DNS); du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1574,7 +1574,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} + ${avg_tcp_connect_time} + ${avg_tls_handshake_time} + ${avg_download_time} as \"Networking Time\"\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total time (including DNS); du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1610,23 +1610,23 @@
           "type": "query"
         },
         {
-          "hide": 2,
-          "name": "timestamp",
-          "query": "startTime",
-          "skipUrlSync": true,
-          "type": "constant",
           "current": {
             "selected": false,
             "text": "startTime",
             "value": "startTime"
           },
+          "hide": 2,
+          "name": "timestamp",
           "options": [
             {
               "selected": false,
               "text": "startTime",
               "value": "startTime"
             }
-          ]
+          ],
+          "query": "startTime",
+          "skipUrlSync": true,
+          "type": "constant"
         },
         {
           "baseFilters": [],
@@ -1650,42 +1650,42 @@
           "type": "query"
         },
         {
+          "current": {
+            "selected": false,
+            "text": "__SUMMARY_TABLE_NAME_1__",
+            "value": "__SUMMARY_TABLE_NAME_1__"
+          },
           "hide": 2,
           "name": "apicontext_sampled_day",
+          "options": [
+            {
+              "selected": false,
+              "text": "__SUMMARY_TABLE_NAME_1__",
+              "value": "__SUMMARY_TABLE_NAME_1__"
+            }
+          ],
           "query": "__SUMMARY_TABLE_NAME_1__",
           "skipUrlSync": true,
-          "type": "constant",
-          "current": {
-            "value": "__SUMMARY_TABLE_NAME_1__",
-            "text": "__SUMMARY_TABLE_NAME_1__",
-            "selected": false
-          },
-          "options": [
-            {
-              "value": "__SUMMARY_TABLE_NAME_1__",
-              "text": "__SUMMARY_TABLE_NAME_1__",
-              "selected": false
-            }
-          ]
+          "type": "constant"
         },
         {
+          "current": {
+            "selected": false,
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
+          },
           "hide": 2,
           "name": "logs",
-          "query": "__PROJECT_NAME__.__TABLE_NAME__",
-          "skipUrlSync": true,
-          "type": "constant",
-          "current": {
-            "value": "__PROJECT_NAME__.__TABLE_NAME__",
-            "text": "__PROJECT_NAME__.__TABLE_NAME__",
-            "selected": false
-          },
           "options": [
             {
-              "value": "__PROJECT_NAME__.__TABLE_NAME__",
+              "selected": false,
               "text": "__PROJECT_NAME__.__TABLE_NAME__",
-              "selected": false
+              "value": "__PROJECT_NAME__.__TABLE_NAME__"
             }
-          ]
+          ],
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant"
         },
         {
           "current": {},

--- a/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
+++ b/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
@@ -10,51 +10,51 @@
     },
     "__requires": [
       {
-        "type": "panel",
         "id": "barchart",
         "name": "Bar chart",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "geomap",
         "name": "Geomap",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "grafana",
         "id": "grafana",
         "name": "Grafana",
+        "type": "grafana",
         "version": "12.0.2"
       },
       {
-        "type": "datasource",
         "id": "hydrolix-hydrolix-datasource",
         "name": "Hydrolix",
+        "type": "datasource",
         "version": "0.6.0"
       },
       {
-        "type": "panel",
         "id": "piechart",
         "name": "Pie chart",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "table",
         "name": "Table",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "text",
         "name": "Text",
+        "type": "panel",
         "version": ""
       },
       {
-        "type": "panel",
         "id": "timeseries",
         "name": "Time series",
+        "type": "panel",
         "version": ""
       }
     ],
@@ -544,7 +544,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -666,7 +666,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -788,7 +788,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
             "refId": "A"
           }
         ],
@@ -910,7 +910,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -1032,7 +1032,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
             "refId": "A"
           }
         ],
@@ -1154,7 +1154,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
             "refId": "A"
           }
         ],
@@ -2004,7 +2004,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "timeseries",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
             "refId": "A"
           }
         ],
@@ -2293,7 +2293,7 @@
             },
             "pluginVersion": "4.0.6",
             "queryType": "table",
-            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL $__interval_s SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
             "refId": "A"
           }
         ],
@@ -2422,23 +2422,23 @@
           "type": "query"
         },
         {
-          "hide": 2,
-          "name": "timestamp",
-          "query": "startTime",
-          "skipUrlSync": true,
-          "type": "constant",
           "current": {
             "selected": false,
             "text": "startTime",
             "value": "startTime"
           },
+          "hide": 2,
+          "name": "timestamp",
           "options": [
             {
               "selected": false,
               "text": "startTime",
               "value": "startTime"
             }
-          ]
+          ],
+          "query": "startTime",
+          "skipUrlSync": true,
+          "type": "constant"
         },
         {
           "baseFilters": [],
@@ -2462,42 +2462,42 @@
           "type": "query"
         },
         {
+          "current": {
+            "selected": false,
+            "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+            "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
+          },
           "hide": 2,
           "name": "apicontext_sampled_day",
-          "query": "__SUMMARY_TABLE_NAME_1__",
-          "skipUrlSync": true,
-          "type": "constant",
-          "current": {
-            "value": "__SUMMARY_TABLE_NAME_1__",
-            "text": "__SUMMARY_TABLE_NAME_1__",
-            "selected": false
-          },
           "options": [
             {
-              "value": "__SUMMARY_TABLE_NAME_1__",
-              "text": "__SUMMARY_TABLE_NAME_1__",
-              "selected": false
+              "selected": false,
+              "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+              "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
             }
-          ]
+          ],
+          "query": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+          "skipUrlSync": true,
+          "type": "constant"
         },
         {
+          "current": {
+            "selected": false,
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
+          },
           "hide": 2,
           "name": "logs",
-          "query": "__PROJECT_NAME__.__TABLE_NAME__",
-          "skipUrlSync": true,
-          "type": "constant",
-          "current": {
-            "value": "__PROJECT_NAME__.__TABLE_NAME__",
-            "text": "__PROJECT_NAME__.__TABLE_NAME__",
-            "selected": false
-          },
           "options": [
             {
-              "value": "__PROJECT_NAME__.__TABLE_NAME__",
+              "selected": false,
               "text": "__PROJECT_NAME__.__TABLE_NAME__",
-              "selected": false
+              "value": "__PROJECT_NAME__.__TABLE_NAME__"
             }
-          ]
+          ],
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant"
         },
         {
           "current": {},

--- a/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
+++ b/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
@@ -2464,18 +2464,18 @@
         {
           "hide": 2,
           "name": "apicontext_sampled_day",
-          "query": "__APICONTEXT_SAMPLED_DAY__",
+          "query": "__SUMMARY_TABLE_NAME_1__",
           "skipUrlSync": true,
           "type": "constant",
           "current": {
-            "value": "__APICONTEXT_SAMPLED_DAY__",
-            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "value": "__SUMMARY_TABLE_NAME_1__",
+            "text": "__SUMMARY_TABLE_NAME_1__",
             "selected": false
           },
           "options": [
             {
-              "value": "__APICONTEXT_SAMPLED_DAY__",
-              "text": "__APICONTEXT_SAMPLED_DAY__",
+              "value": "__SUMMARY_TABLE_NAME_1__",
+              "text": "__SUMMARY_TABLE_NAME_1__",
               "selected": false
             }
           ]

--- a/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
+++ b/trafficpeak/apicontext/dashboards/network-monitoring-dashboard-synthetics.json
@@ -1,0 +1,2743 @@
+{
+  "dashboard": {
+    "__elements": {
+      "model": {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        }
+      }
+    },
+    "__requires": [
+      {
+        "type": "panel",
+        "id": "barchart",
+        "name": "Bar chart",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "geomap",
+        "name": "Geomap",
+        "version": ""
+      },
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "12.0.2"
+      },
+      {
+        "type": "datasource",
+        "id": "hydrolix-hydrolix-datasource",
+        "name": "Hydrolix",
+        "version": "0.6.0"
+      },
+      {
+        "type": "panel",
+        "id": "piechart",
+        "name": "Pie chart",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "table",
+        "name": "Table",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "text",
+        "name": "Text",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "timeseries",
+        "name": "Time series",
+        "version": ""
+      }
+    ],
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "description": "",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 18,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "Reports on network times, multi-cloud information, and API workflows.",
+          "mode": "markdown"
+        },
+        "pluginVersion": "12.0.2",
+        "title": "Network Monitoring Dashboard (Synthetics)",
+        "type": "text"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows network issues and for each Cloud and Region",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [
+              {
+                "options": {
+                  "1-green": {
+                    "color": "green",
+                    "index": 2
+                  },
+                  "2-yellow": {
+                    "color": "orange",
+                    "index": 1
+                  },
+                  "3-red": {
+                    "color": "dark-red",
+                    "index": 0
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 19,
+          "w": 24,
+          "x": 0,
+          "y": 2
+        },
+        "id": 17,
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "arrow": 1,
+                "edgeStyle": {
+                  "color": {
+                    "field": "edge_color_text",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "edge_thickness",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "field": "network_time",
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                },
+                "showLegend": false,
+                "style": {
+                  "color": {
+                    "field": "cloud_provider",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "cloud_provider",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "location": {
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "mode": "coords"
+              },
+              "name": "Layer 3",
+              "tooltip": true,
+              "type": "network"
+            },
+            {
+              "config": {
+                "showLegend": false,
+                "style": {
+                  "color": {
+                    "field": "cloud_provider",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "network_time",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "field": "cloud_provider",
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "right",
+                    "textBaseline": "bottom"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "nodes"
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Layer 2",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 15.767144,
+            "lon": -1.234589,
+            "zoom": 2
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "call_id",
+                  "type": "String"
+                }
+              ],
+              "database": "default",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "apic2"
+            },
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "hide": false,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "call_id",
+                    "type": "String"
+                  }
+                ],
+                "database": "default",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "list",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "apic2"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT DISTINCT \n    CONCAT(callID, '_', resultID) AS id,  \n    ipAddr AS ip_address,\n    ${ipAddr_latitude} AS latitude,  \n    ${ipAddr_longitude} AS longitude,\n    cloud AS cloud_provider,\n    ${ipAddr_city} AS city\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND ipAddr != '~~~SAMPLED_OUT~~~'\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND notEmpty(cloud_provider)\nAND NOT (\n    -- Exclude Private IPs\n    ipAddr LIKE '10.%' OR ipAddr LIKE '172.16.%' OR ipAddr LIKE '172.17.%' OR ipAddr LIKE '172.18.%' \n    OR ipAddr LIKE '172.19.%' OR ipAddr LIKE '172.20.%' OR ipAddr LIKE '172.21.%' OR ipAddr LIKE '172.22.%' \n    OR ipAddr LIKE '172.23.%' OR ipAddr LIKE '172.24.%' OR ipAddr LIKE '172.25.%' OR ipAddr LIKE '172.26.%' \n    OR ipAddr LIKE '172.27.%' OR ipAddr LIKE '172.28.%' OR ipAddr LIKE '172.29.%' OR ipAddr LIKE '172.30.%' \n    OR ipAddr LIKE '172.31.%' OR ipAddr LIKE '192.168.%' OR ipAddr LIKE '169.254.%' OR ipAddr LIKE '127.%'\n)\nLIMIT 300\n\nUNION ALL \n\nSELECT DISTINCT \n    CONCAT(resultID, '_', callID) AS id,  \n    targetIPAddr AS ip_address,\n    ${targetIPAddr_latitude} AS latitude,  \n    ${targetIPAddr_longitude} AS longitude,\n    targetCloud AS cloud_provider,\n    ${targetIPAddr_city} AS city\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND targetIPAddr != '~~~SAMPLED_OUT~~~'\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND notEmpty(cloud_provider)\nAND NOT (\n    -- Exclude Private IPs\n    targetIPAddr LIKE '10.%' OR targetIPAddr LIKE '172.16.%' OR targetIPAddr LIKE '172.17.%' OR targetIPAddr LIKE '172.18.%' \n    OR targetIPAddr LIKE '172.19.%' OR targetIPAddr LIKE '172.20.%' OR targetIPAddr LIKE '172.21.%' OR targetIPAddr LIKE '172.22.%' \n    OR targetIPAddr LIKE '172.23.%' OR targetIPAddr LIKE '172.24.%' OR targetIPAddr LIKE '172.25.%' OR targetIPAddr LIKE '172.26.%' \n    OR targetIPAddr LIKE '172.27.%' OR targetIPAddr LIKE '172.28.%' OR targetIPAddr LIKE '172.29.%' OR targetIPAddr LIKE '172.30.%' \n    OR targetIPAddr LIKE '172.31.%' OR targetIPAddr LIKE '192.168.%' OR targetIPAddr LIKE '169.254.%' OR targetIPAddr LIKE '127.%'\n)\n\nORDER BY id\nLIMIT 300\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking issues for all API calls; query=nodes; du=${__user.login}'",
+            "refId": "nodes"
+          },
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "call_id",
+                  "type": "String"
+                }
+              ],
+              "database": "default",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "apic2"
+            },
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "hide": false,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "call_id",
+                    "type": "String"
+                  }
+                ],
+                "database": "default",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "list",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "apic2"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n    CONCAT(callID, '_', resultID) AS source,   -- 👈 Ensure this matches the node ID\n    CONCAT(resultID, '_', callID) AS target,   -- 👈 Ensure this matches the node ID\n    (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) AS network_time, -- Network Time Calculation\n    cloud AS source_cloud, \n    targetCloud AS target_cloud, \n    ${ipAddr_city} AS source_city, \n    ${targetIPAddr_city} AS target_city,\n\n    -- 🚦 Edge Coloring Logic\n    CASE \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) < 50 THEN '1-green'   \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) BETWEEN 50 AND 200 THEN '2-yellow'  \n        ELSE '3-red'   \n    END AS edge_color_text,\n\n    -- 🔹 Edge Thickness based on Performance\n    CASE \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) < 50 THEN 2  \n        WHEN (${sum_dns} + ${sum_connect} + ${sum_tlsHandshake}) BETWEEN 50 AND 200 THEN 4  \n        ELSE 6  \n    END AS edge_thickness\n\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n-- 🔴 Remove Private IPs & Blank Target IPs\nAND isNotNull(targetIPAddr)\nAND notEmpty(targetIPAddr)\nAND isNotNull(ipAddr)\nAND notEmpty(target_city)\n\nAND callID != '~~~SAMPLED_OUT~~~'\nAND resultID != '~~~SAMPLED_OUT~~~'\nAND NOT (\n    -- Exclude Private IPs (Source)\n    ipAddr LIKE '10.%'\n    OR ipAddr LIKE '172.16.%' OR ipAddr LIKE '172.17.%' OR ipAddr LIKE '172.18.%' OR ipAddr LIKE '172.19.%'\n    OR ipAddr LIKE '172.20.%' OR ipAddr LIKE '172.21.%' OR ipAddr LIKE '172.22.%' OR ipAddr LIKE '172.23.%'\n    OR ipAddr LIKE '172.24.%' OR ipAddr LIKE '172.25.%' OR ipAddr LIKE '172.26.%' OR ipAddr LIKE '172.27.%'\n    OR ipAddr LIKE '172.28.%' OR ipAddr LIKE '172.29.%' OR ipAddr LIKE '172.30.%' OR ipAddr LIKE '172.31.%'\n    OR ipAddr LIKE '192.168.%'\n    OR ipAddr LIKE '169.254.%'\n    OR ipAddr LIKE '127.%'\n\n    -- Exclude Private IPs (Target)\n    OR targetIPAddr LIKE '10.%'\n    OR targetIPAddr LIKE '172.16.%' OR targetIPAddr LIKE '172.17.%' OR targetIPAddr LIKE '172.18.%' OR targetIPAddr LIKE '172.19.%'\n    OR targetIPAddr LIKE '172.20.%' OR targetIPAddr LIKE '172.21.%' OR targetIPAddr LIKE '172.22.%' OR targetIPAddr LIKE '172.23.%'\n    OR targetIPAddr LIKE '172.24.%' OR targetIPAddr LIKE '172.25.%' OR targetIPAddr LIKE '172.26.%' OR targetIPAddr LIKE '172.27.%'\n    OR targetIPAddr LIKE '172.28.%' OR targetIPAddr LIKE '172.29.%' OR targetIPAddr LIKE '172.30.%' OR targetIPAddr LIKE '172.31.%'\n    OR targetIPAddr LIKE '192.168.%'\n    OR targetIPAddr LIKE '169.254.%'\n    OR targetIPAddr LIKE '127.%'\n)\nGROUP BY source, target, source_cloud, target_cloud, source_city, target_city, startTime\nORDER BY ${timestamp} DESC  -- 🕒 Sort by most recent data\nLIMIT 300  -- 📉 Keep results manageable\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Networking issues for all API calls; query=edges; du=${__user.login}'",
+            "refId": "edges"
+          }
+        ],
+        "title": "Networking issues for all API calls",
+        "type": "geomap"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the average Connect time for each metadataDomain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 21
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tcp_connect_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average TCP connect time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average TCP connect time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the average tlsHandshake time for each metadataDomain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 21
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average SSL handshake time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average SSL handshake time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the average DNS time for each Metadata Domain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 32
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_dns_lookup_time} AS AVG, \n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nORDER BY AVG DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average DNS lookup time; du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Average DNS lookup time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the average Response Time for each Metadata Domain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 32
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_responseTime} AS AVG,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Average response time; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Average response time",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the sum of the averages of TlsHandshake, Connect, and DNS for each Metadata Domain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 43
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time,\n  metadataDomain\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (DNS + TCP + SSL); du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Total networking time (DNS + TCP + SSL)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the Cloud, Connect, and DNS average time for each Cloud.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 43
+        },
+        "id": 16,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Max",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  ${avg_tls_handshake_time} + ${avg_tcp_connect_time} + ${avg_dns_lookup_time} AS Time, \n  cloud\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, cloud\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Total networking time (By Cloud); du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Total networking time (By Cloud)",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the Average Response Time groping by Location ID and cloud.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-GrYlRd"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [
+              {
+                "options": {
+                  "AWS": {
+                    "color": "orange",
+                    "index": 1
+                  },
+                  "Akamai": {
+                    "color": "yellow",
+                    "index": 2
+                  },
+                  "Azure": {
+                    "color": "blue",
+                    "index": 0
+                  },
+                  "Google": {
+                    "color": "green",
+                    "index": 4
+                  },
+                  "IBM": {
+                    "color": "red",
+                    "index": 3
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "latitude"
+              },
+              "properties": [
+                {
+                  "id": "custom.hideFrom",
+                  "value": {
+                    "legend": true,
+                    "tooltip": true,
+                    "viz": true
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "longitude"
+              },
+              "properties": [
+                {
+                  "id": "custom.hideFrom",
+                  "value": {
+                    "legend": true,
+                    "tooltip": true,
+                    "viz": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 54
+        },
+        "id": 6,
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": false,
+                "style": {
+                  "color": {
+                    "field": "cloud",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "AvgResponseTime",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Latency",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "zero",
+            "lat": 0,
+            "lon": 0,
+            "zoom": 1
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "avg",
+                  "alias": "AvgResponseTime",
+                  "column": "dns"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "latitude",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "longitude",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "cloud",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "locationID",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "apicontext",
+              "filters": [
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "startTime",
+                  "operator": "WITH IN DASHBOARD TIME RANGE",
+                  "type": "DateTime",
+                  "value": "TODAY"
+                },
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "metadataDomain",
+                  "operator": "LIKE",
+                  "type": "Nullable(String)",
+                  "value": "'%${domain_name}%'"
+                }
+              ],
+              "groupBy": [
+                "locationID",
+                "longitude",
+                "latitude",
+                "cloud"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "logs"
+            },
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "avg",
+                    "alias": "AvgResponseTime",
+                    "column": "dns"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "latitude",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "longitude",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "cloud",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "locationID",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "apicontext",
+                "filters": [
+                  {
+                    "condition": "AND",
+                    "filterType": "custom",
+                    "key": "startTime",
+                    "operator": "WITH IN DASHBOARD TIME RANGE",
+                    "type": "DateTime",
+                    "value": "TODAY"
+                  },
+                  {
+                    "condition": "AND",
+                    "filterType": "custom",
+                    "key": "metadataDomain",
+                    "operator": "LIKE",
+                    "type": "Nullable(String)",
+                    "value": "'%${domain_name}%'"
+                  }
+                ],
+                "groupBy": [
+                  "locationID",
+                  "longitude",
+                  "latitude",
+                  "cloud"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "logs"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  ${ipAddr_latitude} AS Latitude, \n  ${ipAddr_longitude} AS Longitude, \n  cloud, \n  locationID, \n  ${avg_dns_lookup_time} as AvgResponseTime \nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})  \n  AND $__adHocFilter()\n  AND Latitude != '0'\n  AND Longitude != '0'\nGROUP BY locationID, Longitude, Latitude, cloud\nLIMIT 500\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=DNS around the world; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "DNS around the world",
+        "type": "geomap"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the Average time for Connect, Proccesing and TlsHandShake.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "left",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "log": 2,
+                "type": "log"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "dashed"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 0
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 100
+                },
+                {
+                  "color": "#EF843C",
+                  "value": 200
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 54
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "min",
+              "mean",
+              "max",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Name",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "hide": false,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n    toStartOfInterval(${timestamp}, INTERVAL 300 SECOND) AS time, \n    ${avg_tcp_connect_time} AS avg_connect, \n    ${avg_processing_time} AS avg_processing, \n    ${avg_tls_handshake_time} AS avg_tls_handshake\nFROM ${table}\nWHERE \n    ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n    AND $__adHocFilter()\nGROUP BY time\nORDER BY time ASC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Latency Breakdown by Metric; du=${__user.login}'",
+            "refId": "B"
+          }
+        ],
+        "title": "Latency Breakdown by Metric",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the total requests for each Metadata Domain.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 65
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "values": [
+              "percent",
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  metadataDomain,\n  COUNT() as Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY metadataDomain\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top Domains; du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Top Domains",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the total requests and tlsHandshake average time for each Region.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 65
+        },
+        "id": 4,
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "error_rate",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "error_rate",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Error Rate",
+              "tooltip": true,
+              "type": "markers"
+            },
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "avg_tls_handshake",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "avg_tls_handshake",
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Avg TLS Handshake",
+              "tooltip": true,
+              "type": "markers"
+            },
+            {
+              "config": {
+                "blur": 15,
+                "radius": 5,
+                "weight": {
+                  "field": "failed_requests",
+                  "fixed": 1,
+                  "max": 1,
+                  "min": 0
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "A"
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Failed Requests",
+              "opacity": 0.4,
+              "tooltip": true,
+              "type": "heatmap"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "zero",
+            "lat": 0,
+            "lon": 0,
+            "zoom": 1
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n    ${ipAddr_city} as region,\n    ${ipAddr_latitude} AS latitude, \n    ${ipAddr_longitude} AS longitude, \n    ${avg_tls_handshake_time} AS avg_tls_handshake,\n    ${failed_requests} AS failed_requests,\n    ${cnt_all} AS total_requests,\n    ${error_rate} AS error_rate\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(region)\nGROUP BY region, latitude, longitude\nORDER BY region\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Combined Regional SLA Heatmap; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Combined Regional SLA Heatmap",
+        "type": "geomap"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the total requests for each Context Category.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 14,
+          "w": 12,
+          "x": 0,
+          "y": 76
+        },
+        "id": 15,
+        "options": {
+          "barRadius": 0,
+          "barWidth": 1,
+          "fullHighlight": true,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [
+              "sum"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Total",
+            "sortDesc": true
+          },
+          "orientation": "auto",
+          "showValue": "auto",
+          "stacking": "percent",
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "time",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 0,
+            "hide": false,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "timeseries",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  contextCategory,\n  ${cnt_all} AS Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, contextCategory\nORDER BY time\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Categories; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Categories",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "barchart"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the TlsHandshake average time for each Region and Cloud",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "dark-green",
+                  "value": 65
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 100
+                },
+                {
+                  "color": "dark-blue",
+                  "value": 150
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 200
+                },
+                {
+                  "color": "red",
+                  "value": 250
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 14,
+          "w": 12,
+          "x": 12,
+          "y": 76
+        },
+        "id": 3,
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "avg_tls_handshake",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.3,
+                  "rotation": {
+                    "field": "avg_tls_handshake",
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "clamped"
+                  },
+                  "size": {
+                    "field": "avg_tls_handshake",
+                    "fixed": 5,
+                    "max": 40,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "A"
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "ms",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": false,
+            "id": "fit",
+            "lastOnly": false,
+            "lat": 0,
+            "layer": "ms",
+            "lon": 0,
+            "zoom": 15
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 0,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "timeseries",
+            "rawSql": "SELECT \n    ${ipAddr_city} as region, \n    ${ipAddr_latitude} AS latitude,\n    ${ipAddr_longitude} AS longitude,\n    cloud,\n    ${avg_tls_handshake_time} AS avg_tls_handshake\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(region)\nGROUP BY region, latitude, longitude, cloud\nORDER BY avg_tls_handshake DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Regional TLS Handshake Performance; du=${__user.login}'",
+            "refId": "A"
+          }
+        ],
+        "title": "Regional TLS Handshake Performance",
+        "transparent": true,
+        "type": "geomap"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the total requests for each Status Code.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 12,
+          "x": 0,
+          "y": 90
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "sum"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true,
+            "sortBy": "Total",
+            "sortDesc": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  toStartOfInterval(${timestamp}, INTERVAL ${__interval_s:raw} SECOND) AS time,\n  toString(httpCode) as statusCode,\n  ${cnt_all} as Code\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\nGROUP BY time, statusCode\nORDER BY Code DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=\"Total Code\" codes; du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP Status Codes",
+        "transformations": [
+          {
+            "id": "prepareTimeSeries",
+            "options": {
+              "format": "multi"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "hydrolix-hydrolix-datasource",
+          "uid": "__DATASOURCE__"
+        },
+        "description": "Shows the total requests for each Cloud and Continent.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "links": [],
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "cloud"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 203
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 12,
+          "x": 12,
+          "y": 90
+        },
+        "id": 14,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": []
+        },
+        "pluginVersion": "12.0.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "hydrolix-hydrolix-datasource",
+              "uid": "__DATASOURCE__"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT \n  cloud as Cloud, \n  ${ipAddr_continent} as Continent,\n  ${cnt_all} as Total\nFROM ${table}\nWHERE ${timestamp} >= toDateTime(${__from:date:seconds}) AND ${timestamp} <= toDateTime(${__to:date:seconds})\n  AND $__adHocFilter()\n  AND notEmpty(Continent)\nGROUP BY Cloud, Continent\nORDER BY Total DESC\nLIMIT 10000\nSETTINGS hdx_query_max_execution_time=60, hdx_query_admin_comment='db=${__dashboard}; dp=Top location IDs; du=${__user.login}'\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Top location IDs",
+        "type": "table"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 41,
+    "tags": [
+      "v1.0",
+      "Required tables: apicontext_sampled_day"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "definition": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+          "hide": 2,
+          "name": "table",
+          "options": [],
+          "query": "SELECT  CASE\nWHEN ${duration} <= 6 THEN '${logs}'\nWHEN ${duration} > 6 THEN '${apicontext_sampled_day}'\nEND",
+          "refresh": 1,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "hide": 2,
+          "name": "timestamp",
+          "query": "startTime",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "selected": false,
+            "text": "startTime",
+            "value": "startTime"
+          },
+          "options": [
+            {
+              "selected": false,
+              "text": "startTime",
+              "value": "startTime"
+            }
+          ]
+        },
+        {
+          "baseFilters": [],
+          "datasource": {
+            "type": "hydrolix-hydrolix-datasource",
+            "uid": "__DATASOURCE__"
+          },
+          "filters": [],
+          "name": "filter",
+          "type": "adhoc"
+        },
+        {
+          "current": {},
+          "definition": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+          "hide": 2,
+          "name": "duration",
+          "options": [],
+          "query": "SELECT dateDiff('hour', toDateTime(${__from:date:seconds}), toDateTime(${__to:date:seconds}))",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "hide": 2,
+          "name": "apicontext_sampled_day",
+          "query": "__APICONTEXT_SAMPLED_DAY__",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "value": "__APICONTEXT_SAMPLED_DAY__",
+            "text": "__APICONTEXT_SAMPLED_DAY__",
+            "selected": false
+          },
+          "options": [
+            {
+              "value": "__APICONTEXT_SAMPLED_DAY__",
+              "text": "__APICONTEXT_SAMPLED_DAY__",
+              "selected": false
+            }
+          ]
+        },
+        {
+          "hide": 2,
+          "name": "logs",
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant",
+          "current": {
+            "value": "__PROJECT_NAME__.__TABLE_NAME__",
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "selected": false
+          },
+          "options": [
+            {
+              "value": "__PROJECT_NAME__.__TABLE_NAME__",
+              "text": "__PROJECT_NAME__.__TABLE_NAME__",
+              "selected": false
+            }
+          ]
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+          "hide": 2,
+          "name": "cnt_all",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'COUNT()',\n'cnt_all'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+          "hide": 2,
+          "name": "avg_responseTime",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(responseTime)',\n'avg_responseTime'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+          "hide": 2,
+          "name": "avg_dns_lookup_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(dns)',\n'avg_dns_lookup_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+          "hide": 2,
+          "name": "avg_tcp_connect_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(connect)',\n'avg_tcp_connect_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+          "hide": 2,
+          "name": "avg_tls_handshake_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(tlsHandshake)',\n'avg_tls_handshake_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+          "hide": 2,
+          "name": "avg_processing_time",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'AVG(processing)',\n'avg_processing_time'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'sumIf(1, contextCategory = \\'FAIL\\')',\n'failed_requests'\n)",
+          "hide": 2,
+          "name": "failed_requests",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'sumIf(1, contextCategory = \\'FAIL\\')',\n'failed_requests'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'(sumIf (1, contextCategory = \\'FAIL\\')/ count()) * 100',\n'error_rate'\n)",
+          "hide": 2,
+          "name": "error_rate",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'(sumIf (1, contextCategory = \\'FAIL\\')/ count()) * 100',\n'error_rate'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', ipAddr)'\n)",
+          "hide": 2,
+          "name": "ipAddr_latitude",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', ipAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'longitude',\n'akamai_geo(\\'longitude\\', ipAddr)'\n)",
+          "hide": 2,
+          "name": "ipAddr_longitude",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'longitude',\n'akamai_geo(\\'longitude\\', ipAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT 'continent'",
+          "hide": 2,
+          "name": "ipAddr_continent",
+          "options": [],
+          "query": "SELECT 'continent'",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(ipAddr)'\n)",
+          "hide": 2,
+          "name": "ipAddr_city",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(ipAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(targetIPAddr)'\n)",
+          "hide": 2,
+          "name": "targetIPAddr_city",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'region',\n'akamai_city_name(targetIPAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', targetIPAddr)'\n)",
+          "hide": 2,
+          "name": "targetIPAddr_latitude",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'latitude\\', targetIPAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'longitude\\', targetIPAddr)'\n)",
+          "hide": 2,
+          "name": "targetIPAddr_longitude",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'latitude',\n'akamai_geo(\\'longitude\\', targetIPAddr)'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(dns)',\n'sum_dns'\n)",
+          "hide": 2,
+          "name": "sum_dns",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(dns)',\n'sum_dns'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(connect)',\n'sum_connect'\n)",
+          "hide": 2,
+          "name": "sum_connect",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(connect)',\n'sum_connect'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "definition": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(tlsHandshake)',\n'sum_tlsHandshake'\n)",
+          "hide": 2,
+          "name": "sum_tlsHandshake",
+          "options": [],
+          "query": "SELECT IF(\n'${table}' = '${logs}',\n'SUM(tlsHandshake)',\n'sum_tlsHandshake'\n)",
+          "refresh": 2,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "__PROJECT_NAME__.__TABLE_NAME__",
+            "value": "__PROJECT_NAME__.__TABLE_NAME__"
+          },
+          "hide": 2,
+          "name": "raw_table",
+          "options": [
+            {
+              "selected": false,
+              "text": "__PROJECT_NAME__.__TABLE_NAME__",
+              "value": "__PROJECT_NAME__.__TABLE_NAME__"
+            }
+          ],
+          "query": "__PROJECT_NAME__.__TABLE_NAME__",
+          "skipUrlSync": true,
+          "type": "constant"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30d",
+      "to": "now"
+    },
+    "timepicker": {
+      "nowDelay": "1m",
+      "refresh_intervals": [
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "utc",
+    "title": "Network Monitoring Dashboard (Synthetics)",
+    "uid": "__DASHBOARD_UUID__",
+    "version": 14,
+    "weekStart": ""
+  }
+}

--- a/trafficpeak/apicontext/summaries/apicontext_sampled_day.sql
+++ b/trafficpeak/apicontext/summaries/apicontext_sampled_day.sql
@@ -1,0 +1,75 @@
+SELECT
+  toStartOfDay (startTime) AS startTime,
+  httpCode,
+  contextCategory,
+  locationID,
+  IF(
+    cityHash64 (metadataDomain, startTime, resultID) % 100 < 10,
+    metadataDomain,
+    '~~~SAMPLED_OUT~~~'
+  ) AS metadataDomain,
+  cloud,
+  targetCloud,
+  IF(
+    cityHash64 (ipAddr, startTime, resultID) % 100 < 10,
+    ipAddr,
+    '~~~SAMPLED_OUT~~~'
+  ) AS ipAddr,
+  IF(
+    cityHash64 (targetIPAddr, startTime, resultID) % 100 < 10,
+    targetIPAddr,
+    '~~~SAMPLED_OUT~~~'
+  ) AS targetIPAddr,
+  city,
+  continent,
+  IF(
+    cityHash64 (callURL, startTime, resultID) % 100 < 10,
+    callURL,
+    '~~~SAMPLED_OUT~~~'
+  ) AS callURL,
+  IF(
+    cityHash64 (callID, startTime, resultID) % 100 < 10,
+    callID,
+    '~~~SAMPLED_OUT~~~'
+  ) AS callID,
+  IF(
+    cityHash64 (resultID, startTime) % 100 < 1,
+    resultID,
+    '~~~SAMPLED_OUT~~~'
+  ) AS resultID,
+  IF(
+    cityHash64 (apiCreationTime, startTime, resultID) % 100 < 10,
+    apiCreationTime,
+    null
+  ) AS apiCreationTime,
+  COUNT(*) AS cnt_all,
+  AVG(responseTime) AS avg_responseTime,
+  AVG(dns) AS avg_dns_lookup_time,
+  AVG(connect) AS avg_tcp_connect_time,
+  AVG(tlsHandshake) AS avg_tls_handshake_time,
+  AVG(upload) AS avg_upload_time,
+  AVG(processing) AS avg_processing_time,
+  AVG(download) AS avg_download_time,
+  SUM(dns) AS sum_dns,
+  SUM(connect) AS sum_connect,
+  SUM(tlsHandshake) AS sum_tlsHandshake,
+  sumIf (1, contextCategory = 'FAIL') AS failed_requests,
+  (failed_requests / cnt_all) * 100 AS error_rate
+FROM
+  __PROJECT_NAME__.__TABLE_NAME__
+GROUP BY
+  startTime,
+  httpCode,
+  locationID,
+  contextCategory,
+  metadataDomain,
+  cloud,
+  targetCloud,
+  city,
+  continent,
+  ipAddr,
+  targetIPAddr,
+  callURL,
+  callID,
+  resultID,
+  apiCreationTime SETTINGS hdx_primary_key = 'startTime'

--- a/trafficpeak/apicontext/transformations/sample_data.json
+++ b/trafficpeak/apicontext/transformations/sample_data.json
@@ -1,73 +1,73 @@
 {
-  "result": "HTTP_CLIENT_ERROR",
   "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+  "call_meta": {
+    "description": "Auto-generated API Call",
+    "domain": "api.sampledata.co.uk",
+    "name": "Example HTTP POST Call",
+    "tags": [
+      "api_type:update",
+      "sector:telecommunications"
+    ]
+  },
+  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
   "context": {
     "_notification": {
-      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "category": "WARNING",
+      "created": "2020-11-27T10:44:19.284152Z",
+      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n",
+      "last_update": "2025-11-28T10:44:19.427550Z",
       "owners": [
         "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
         "public_settings"
-      ],
-      "created": "2019-06-05T17:11:36.444708Z",
-      "category": "WARNING",
-      "viewed_by": [
-        "Martin"
       ],
       "references": [
         "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
         "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
       ],
-      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
-      "last_update": "2024-06-05T17:11:36.588106Z",
-      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "viewed_by": [
+        "Martin"
+      ]
     },
-    "_result_streak": 1,
-    "_result_category": "WARNING"
+    "_result_category": "WARNING",
+    "_result_streak": 1
   },
-  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
-  "call_meta": {
-    "name": "Example HTTP POST Call",
-    "tags": [
-      "api_type:update",
-      "sector:telecommunications"
-    ],
-    "domain": "api.sampledata.co.uk",
-    "description": "Auto-generated API Call"
-  },
-  "http_code": 418,
-  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
-  "upload_ms": 333,
-  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
-  "start_time": "2024-10-07T06:27:17.160556Z",
-  "download_ms": 555,
-  "http_reason": "I'M A TEAPOT",
-  "location_id": "development",
-  "timing_data": {
-    "dns": 2,
-    "upload": 0,
-    "connect": 1,
-    "download": 13522,
-    "processing": 118,
-    "tls_handshake": 234
-  },
-  "workflow_id": null,
-  "result_class": "WARNING",
-  "workflow_url": null,
   "dns_lookup_ms": 111,
+  "download_ms": 555,
+  "http_code": 418,
+  "http_reason": "I'M A TEAPOT",
   "location_data": {
     "city": "london",
     "cloud": "Akamai",
-    "region": "eng",
+    "continent": "EU",
     "country": "GB",
     "ip_addr": "169.254.169.126",
     "latitude": null,
-    "continent": "EU",
-    "longitude": null
+    "longitude": null,
+    "region": "eng"
   },
+  "location_id": "development",
   "processing_ms": 4479,
   "response_size": 135,
   "response_time": 56,
+  "result": "HTTP_CLIENT_ERROR",
+  "result_class": "WARNING",
+  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
   "ssl_handshake_ms": 222,
+  "start_time": "2026-04-01T00:00:00.000000Z",
+  "timing_data": {
+    "connect": 1,
+    "dns": 2,
+    "download": 13522,
+    "processing": 118,
+    "tls_handshake": 234,
+    "upload": 0
+  },
+  "upload_ms": 333,
+  "workflow_id": null,
   "workflow_result_id": null,
-  "workflow_result_url": null
+  "workflow_result_url": null,
+  "workflow_url": null
 }

--- a/trafficpeak/apicontext/transformations/sample_data.json
+++ b/trafficpeak/apicontext/transformations/sample_data.json
@@ -1,0 +1,73 @@
+{
+  "result": "HTTP_CLIENT_ERROR",
+  "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+  "context": {
+    "_notification": {
+      "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+      "owners": [
+        "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
+        "public_settings"
+      ],
+      "created": "2019-06-05T17:11:36.444708Z",
+      "category": "WARNING",
+      "viewed_by": [
+        "Martin"
+      ],
+      "references": [
+        "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+        "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
+      ],
+      "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+      "last_update": "2024-06-05T17:11:36.588106Z",
+      "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+    },
+    "_result_streak": 1,
+    "_result_category": "WARNING"
+  },
+  "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
+  "call_meta": {
+    "name": "Example HTTP POST Call",
+    "tags": [
+      "api_type:update",
+      "sector:telecommunications"
+    ],
+    "domain": "api.sampledata.co.uk",
+    "description": "Auto-generated API Call"
+  },
+  "http_code": 418,
+  "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+  "upload_ms": 333,
+  "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
+  "start_time": "2024-10-07T06:27:17.160556Z",
+  "download_ms": 555,
+  "http_reason": "I'M A TEAPOT",
+  "location_id": "development",
+  "timing_data": {
+    "dns": 2,
+    "upload": 0,
+    "connect": 1,
+    "download": 13522,
+    "processing": 118,
+    "tls_handshake": 234
+  },
+  "workflow_id": null,
+  "result_class": "WARNING",
+  "workflow_url": null,
+  "dns_lookup_ms": 111,
+  "location_data": {
+    "city": "london",
+    "cloud": "Akamai",
+    "region": "eng",
+    "country": "GB",
+    "ip_addr": "169.254.169.126",
+    "latitude": null,
+    "continent": "EU",
+    "longitude": null
+  },
+  "processing_ms": 4479,
+  "response_size": 135,
+  "response_time": 56,
+  "ssl_handshake_ms": 222,
+  "workflow_result_id": null,
+  "workflow_result_url": null
+}

--- a/trafficpeak/apicontext/transformations/transform.json
+++ b/trafficpeak/apicontext/transformations/transform.json
@@ -1,0 +1,1547 @@
+{
+  "name": "default_context_logs",
+  "description": "",
+  "settings": {
+    "is_default": true,
+    "rate_limit": null,
+    "null_values": [],
+    "data_mirroring_target": null,
+    "output_columns": [
+      {
+        "name": "apiCreationTime",
+        "datatype": {
+          "type": "datetime",
+          "index": true,
+          "primary": false,
+          "format": "2006-01-02T15:04:05.999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/created"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "callID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataDescription",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/description"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataDomain",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/domain"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "metadataTagsString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/tags"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "metadataTags",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaOrg",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/organization"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "projectMetaTagsString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/tags"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "projectMetaTags",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "callURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextCategory",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/category"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextDescription",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextDescriptionText",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description_text"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextLastUpdate",
+        "datatype": {
+          "type": "datetime",
+          "index": true,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/last_update"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextOwnersString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/owners"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextOwners",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextReferencesString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/references"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextReferences",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextTitle",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/title"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextViewedString",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/viewed_by"
+            ]
+          },
+          "suppress": true
+        }
+      },
+      {
+        "name": "contextViewed",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextResultCategory",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_category"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "contextResultStreak",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_streak"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "httpCode",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_code"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "dnsLookupMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_lookup_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "sslHandshakeMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/ssl_handshake_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "uploadMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/upload_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "processingMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/processing_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "downloadMSec",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/download_ms"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "httpReason",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_reason"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "locationID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "responseSize",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_size"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "responseTime",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_time"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "result",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultClass",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_class"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "resultURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowId",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowName",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_name"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowResultId",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowResultUrl",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "workflowUrl",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "startTime",
+        "datatype": {
+          "type": "datetime",
+          "index": false,
+          "primary": true,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "resolution": "seconds",
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/start_time"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetURL",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_url"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetIPAddr",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/ip_addr"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCloud",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cloud"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCity",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/city"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetRegion",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/region"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCountry",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/country"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetContinent",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/continent"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetLatitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/latitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetLongitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/longitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetNetwork",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/network"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetCdn",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cdn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "targetAsn",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/asn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "city",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/city"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "cloud",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/cloud"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "ipAddr",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/ip_addr"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "region",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/region"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "country",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/country"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "continent",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/continent"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "latitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/latitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "longitude",
+        "datatype": {
+          "type": "double",
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "ignore": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/longitude"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "dns",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/dns"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "connect",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/connect"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "tlsHandshake",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/tls_handshake"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "upload",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/upload"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "processing",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/processing"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "download",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/download"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "total",
+        "datatype": {
+          "type": "int32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/total"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "aRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/a"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "nsRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/ns"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "cnameRecord",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": false,
+              "primary": false
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/cname"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "otelTraceparentID",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/otel_traceparent_id"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainAgeInDays",
+        "datatype": {
+          "type": "uint32",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/age_in_days"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainDNSProvider",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/dns_provider"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainFQDN",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/fqdn"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainRegistrar",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/registrar"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "domainTLD",
+        "datatype": {
+          "type": "string",
+          "index": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/tld"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "tlsCertificates",
+        "datatype": {
+          "type": "array",
+          "index": false,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": true
+            }
+          ],
+          "source": {
+            "from_json_pointers": [
+              "/tls_certificates"
+            ]
+          },
+          "suppress": false
+        }
+      },
+      {
+        "name": "unknown",
+        "datatype": {
+          "type": "map",
+          "index": true,
+          "catch_all": true,
+          "format": null,
+          "default": null,
+          "script": null,
+          "elements": [
+            {
+              "type": "string",
+              "index": true
+            },
+            {
+              "type": "string",
+              "index": true
+            }
+          ],
+          "source": null,
+          "suppress": true
+        }
+      }
+    ],
+    "compression": "",
+    "wurfl": null,
+    "format_details": {
+      "flattening": {
+        "depth": null,
+        "active": false,
+        "map_flattening_strategy": {
+          "left": "",
+          "right": ""
+        },
+        "slice_flattening_strategy": {
+          "left": "",
+          "right": ""
+        }
+      }
+    },
+    "sql_transform": "SELECT \narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(metadataTagsString))) AS metadataTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(projectMetaTagsString))) AS projectMetaTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextOwnersString))) AS contextOwners,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextReferencesString))) AS contextReferences,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextViewedString))) AS contextViewed,\n* FROM {STREAM}\n",
+    "sample_data": {
+      "result": "HTTP_CLIENT_ERROR",
+      "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+      "context": {
+        "_notification": {
+          "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+          "owners": [
+            "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
+            "public_settings"
+          ],
+          "created": "2019-06-05T17:11:36.444708Z",
+          "category": "WARNING",
+          "viewed_by": [
+            "Martin"
+          ],
+          "references": [
+            "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+            "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
+          ],
+          "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+          "last_update": "2024-06-05T17:11:36.588106Z",
+          "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+        },
+        "_result_streak": 1,
+        "_result_category": "WARNING"
+      },
+      "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
+      "call_meta": {
+        "name": "Example HTTP POST Call",
+        "tags": [
+          "api_type:update",
+          "sector:telecommunications"
+        ],
+        "domain": "api.sampledata.co.uk",
+        "description": "Auto-generated API Call"
+      },
+      "http_code": 418,
+      "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+      "upload_ms": 333,
+      "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
+      "start_time": "2024-10-07T06:27:17.160556Z",
+      "download_ms": 555,
+      "http_reason": "I'M A TEAPOT",
+      "location_id": "development",
+      "timing_data": {
+        "dns": 2,
+        "upload": 0,
+        "connect": 1,
+        "download": 13522,
+        "processing": 118,
+        "tls_handshake": 234
+      },
+      "workflow_id": null,
+      "result_class": "WARNING",
+      "workflow_url": null,
+      "dns_lookup_ms": 111,
+      "location_data": {
+        "city": "london",
+        "cloud": "Akamai",
+        "region": "eng",
+        "country": "GB",
+        "ip_addr": "169.254.169.126",
+        "latitude": null,
+        "continent": "EU",
+        "longitude": null
+      },
+      "processing_ms": 4479,
+      "response_size": 135,
+      "response_time": 56,
+      "ssl_handshake_ms": 222,
+      "workflow_result_id": null,
+      "workflow_result_url": null
+    }
+  },
+  "type": "json"
+}

--- a/trafficpeak/apicontext/transformations/transform.json
+++ b/trafficpeak/apicontext/transformations/transform.json
@@ -1,1463 +1,13 @@
 {
-  "name": "default_context_logs",
   "description": "",
+  "name": "default_context_logs",
   "settings": {
-    "is_default": true,
-    "rate_limit": null,
-    "null_values": [],
-    "data_mirroring_target": null,
-    "output_columns": [
-      {
-        "name": "apiCreationTime",
-        "datatype": {
-          "type": "datetime",
-          "index": true,
-          "primary": false,
-          "format": "2006-01-02T15:04:05.999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/created"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "callID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataDescription",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/description"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataDomain",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/domain"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "metadataTagsString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_meta/tags"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "metadataTags",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaOrg",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/organization"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "projectMetaTagsString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/project_meta/tags"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "projectMetaTags",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "callURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/call_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextCategory",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/category"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextDescription",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/description"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextDescriptionText",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/description_text"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextLastUpdate",
-        "datatype": {
-          "type": "datetime",
-          "index": true,
-          "format": "2006-01-02T15:04:05.999999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/last_update"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextOwnersString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/owners"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextOwners",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextReferencesString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/references"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextReferences",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextTitle",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/title"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextViewedString",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_notification/viewed_by"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "contextViewed",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextResultCategory",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_result_category"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "contextResultStreak",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/context/_result_streak"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "httpCode",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/http_code"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "dnsLookupMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/dns_lookup_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "sslHandshakeMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/ssl_handshake_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "uploadMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/upload_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "processingMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/processing_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "downloadMSec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/download_ms"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "httpReason",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/http_reason"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "locationID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "responseSize",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/response_size"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "responseTime",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/response_time"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "result",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultClass",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_class"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resultURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/result_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowId",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowName",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_name"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowResultId",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_result_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowResultUrl",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_result_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "workflowUrl",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/workflow_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "startTime",
-        "datatype": {
-          "type": "datetime",
-          "index": false,
-          "primary": true,
-          "format": "2006-01-02T15:04:05.999999Z",
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/start_time"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetURL",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_url"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetIPAddr",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/ip_addr"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCloud",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/cloud"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCity",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/city"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetRegion",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/region"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCountry",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/country"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetContinent",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/continent"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetLatitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/latitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetLongitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/longitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetNetwork",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/network"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetCdn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/cdn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "targetAsn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/target_data/asn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "city",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/city"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "cloud",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/cloud"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "ipAddr",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/ip_addr"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "region",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/region"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "country",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/country"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "continent",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/continent"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "latitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/latitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "longitude",
-        "datatype": {
-          "type": "double",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/location_data/longitude"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "dns",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/dns"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "connect",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/connect"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "tlsHandshake",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/tls_handshake"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "upload",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/upload"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "processing",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/processing"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "download",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/download"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "total",
-        "datatype": {
-          "type": "int32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/timing_data/total"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "aRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/a"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "nsRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/ns"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "cnameRecord",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": false,
-              "primary": false
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/dns_records/cname"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "otelTraceparentID",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/otel_traceparent_id"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainAgeInDays",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/age_in_days"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainDNSProvider",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/dns_provider"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainFQDN",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/fqdn"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainRegistrar",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/registrar"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "domainTLD",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_json_pointers": [
-              "/domain_data/tld"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "tlsCertificates",
-        "datatype": {
-          "type": "array",
-          "index": false,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/tls_certificates"
-            ]
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "unknown",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "catch_all": true,
-          "format": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": null,
-          "suppress": true
-        }
-      }
-    ],
     "compression": "",
-    "wurfl": null,
+    "data_mirroring_target": null,
     "format_details": {
       "flattening": {
-        "depth": null,
         "active": false,
+        "depth": null,
         "map_flattening_strategy": {
           "left": "",
           "right": ""
@@ -1468,80 +18,1530 @@
         }
       }
     },
-    "sql_transform": "SELECT \narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(metadataTagsString))) AS metadataTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(projectMetaTagsString))) AS projectMetaTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextOwnersString))) AS contextOwners,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextReferencesString))) AS contextReferences,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextViewedString))) AS contextViewed,\n* FROM {STREAM}\n",
+    "is_default": true,
+    "null_values": [],
+    "output_columns": [
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999Z",
+          "index": true,
+          "primary": false,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/created"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "apiCreationTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "callID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/description"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataDescription"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/domain"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataDomain"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "metadataName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_meta/tags"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "metadataTagsString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "metadataTags"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/organization"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "projectMetaOrg"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/project_meta/tags"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "projectMetaTagsString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "projectMetaTags"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/call_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "callURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/category"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextCategory"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextDescription"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/description_text"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextDescriptionText"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "index": true,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/last_update"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "contextLastUpdate"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/owners"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextOwnersString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextOwners"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/references"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextReferencesString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextReferences"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/title"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextTitle"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_notification/viewed_by"
+            ]
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "contextViewedString"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "contextViewed"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_category"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "contextResultCategory"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/context/_result_streak"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "contextResultStreak"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_code"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "httpCode"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_lookup_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "dnsLookupMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/ssl_handshake_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "sslHandshakeMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/upload_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "uploadMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/processing_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "processingMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/download_ms"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "downloadMSec"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/http_reason"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "httpReason"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "locationID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_size"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "responseSize"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/response_time"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "responseTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "result"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_class"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultClass"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/result_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resultURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowId"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_name"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowName"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowResultId"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_result_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowResultUrl"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/workflow_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "workflowUrl"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999999Z",
+          "index": false,
+          "primary": true,
+          "resolution": "seconds",
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/start_time"
+            ]
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "startTime"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_url"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetURL"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/ip_addr"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetIPAddr"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cloud"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCloud"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/city"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCity"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/region"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetRegion"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/country"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCountry"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/continent"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetContinent"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/latitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "targetLatitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/longitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "targetLongitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/network"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetNetwork"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/cdn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetCdn"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/target_data/asn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "targetAsn"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/city"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "city"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/cloud"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "cloud"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/ip_addr"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ipAddr"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/region"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "region"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/country"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "country"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/continent"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "continent"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/latitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "latitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "ignore": false,
+          "index": false,
+          "index_options": {
+            "fulltext": false
+          },
+          "primary": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/location_data/longitude"
+            ]
+          },
+          "suppress": false,
+          "type": "double"
+        },
+        "name": "longitude"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/dns"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "dns"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/connect"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "connect"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/tls_handshake"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "tlsHandshake"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/upload"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "upload"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/processing"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "processing"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/download"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "download"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/timing_data/total"
+            ]
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "total"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/a"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "aRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/ns"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "nsRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": false,
+              "primary": false,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/dns_records/cname"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "cnameRecord"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/otel_traceparent_id"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "otelTraceparentID"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/age_in_days"
+            ]
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "domainAgeInDays"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/dns_provider"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainDNSProvider"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/fqdn"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainFQDN"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/registrar"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainRegistrar"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/domain_data/tld"
+            ]
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "domainTLD"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "elements": [
+            {
+              "index": true,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": false,
+          "script": null,
+          "source": {
+            "from_json_pointers": [
+              "/tls_certificates"
+            ]
+          },
+          "suppress": false,
+          "type": "array"
+        },
+        "name": "tlsCertificates"
+      },
+      {
+        "datatype": {
+          "catch_all": true,
+          "default": null,
+          "elements": [
+            {
+              "index": true,
+              "type": "string"
+            },
+            {
+              "index": true,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": true,
+          "script": null,
+          "source": null,
+          "suppress": true,
+          "type": "map"
+        },
+        "name": "unknown"
+      }
+    ],
+    "rate_limit": null,
     "sample_data": {
-      "result": "HTTP_CLIENT_ERROR",
       "call_id": "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
+      "call_meta": {
+        "description": "Auto-generated API Call",
+        "domain": "api.sampledata.co.uk",
+        "name": "Example HTTP POST Call",
+        "tags": [
+          "api_type:update",
+          "sector:telecommunications"
+        ]
+      },
+      "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
       "context": {
         "_notification": {
-          "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+          "category": "WARNING",
+          "created": "2020-11-27T10:44:19.284152Z",
+          "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
+          "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n",
+          "last_update": "2025-11-28T10:44:19.427550Z",
           "owners": [
             "agxkZXZ-dmlhdGVzdHNyEQsSBFVzZXIYgICAgICA0AoM",
             "public_settings"
-          ],
-          "created": "2019-06-05T17:11:36.444708Z",
-          "category": "WARNING",
-          "viewed_by": [
-            "Martin"
           ],
           "references": [
             "agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM",
             "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA"
           ],
-          "description": "\n<p>\nAPI Call <a href=\"https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/\">\"Example HTTP POST Call\"</a> has failed :\n<ul>\n<li><b>Server returned a 4XX status. There may be a problem with the test.</b></li>\n\n<li>Calling POST http://google.apimetrics.xyz/status/418</li>\n<li>Got response HTTP 418 I&#39;M A TEAPOT</li>\n\n</ul>\n</p>\n\n<p>Timing breakdown:\n<ul>\n\n<li>The total latency was 56 ms.</li>\n<li>DNS Lookup: 4 ms</li>\n<li>Connect: 24 ms</li>\n\n<li>Upload: 0 ms</li>\n<li>Processing: 0 ms</li>\n<li>Download: 28 ms</li>\n\n</ul>\n</p>\n\n\n</p>\n\n<p>\nView details here:\n<a href=\"https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\">https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/</a>\n</p>\n\n<p>Sincerely,<br>\nAPImetrics Team\n</p>\n",
-          "last_update": "2024-06-05T17:11:36.588106Z",
-          "description_text": "\nAPI Call \"Example HTTP POST Call\" (http://localhost:8080/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/) has failed :\n\nServer returned a 4XX status. There may be a problem with the test.\nCalling POST http://google.apimetrics.xyz/status/418\nGot response HTTP 418 I&#39;M A TEAPOT\nTiming breakdown:\n  The total latency was 56 ms.\n  DNS Lookup: 4 ms\n  Connect: 24 ms\n\n  Upload: 0 ms\n  Processing: 0 ms\n  Download: 28 ms\n\n\nView details here: \nhttp://localhost:8080/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/\n\n\nAPImetrics Team\n"
+          "title": "[WARNING]: APImetrics: All Failures: Example HTTP POST Call",
+          "viewed_by": [
+            "Martin"
+          ]
         },
-        "_result_streak": 1,
-        "_result_category": "WARNING"
+        "_result_category": "WARNING",
+        "_result_streak": 1
       },
-      "call_url": "https://client.apimetrics.io/tests/test/agxkZXZ-dmlhdGVzdHNyFwsSClRlc3RTZXR1cDIYgICAgICA0AkM/",
-      "call_meta": {
-        "name": "Example HTTP POST Call",
-        "tags": [
-          "api_type:update",
-          "sector:telecommunications"
-        ],
-        "domain": "api.sampledata.co.uk",
-        "description": "Auto-generated API Call"
-      },
-      "http_code": 418,
-      "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
-      "upload_ms": 333,
-      "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
-      "start_time": "2024-10-07T06:27:17.160556Z",
-      "download_ms": 555,
-      "http_reason": "I'M A TEAPOT",
-      "location_id": "development",
-      "timing_data": {
-        "dns": 2,
-        "upload": 0,
-        "connect": 1,
-        "download": 13522,
-        "processing": 118,
-        "tls_handshake": 234
-      },
-      "workflow_id": null,
-      "result_class": "WARNING",
-      "workflow_url": null,
       "dns_lookup_ms": 111,
+      "download_ms": 555,
+      "http_code": 418,
+      "http_reason": "I'M A TEAPOT",
       "location_data": {
         "city": "london",
         "cloud": "Akamai",
-        "region": "eng",
+        "continent": "EU",
         "country": "GB",
         "ip_addr": "169.254.169.126",
         "latitude": null,
-        "continent": "EU",
-        "longitude": null
+        "longitude": null,
+        "region": "eng"
       },
+      "location_id": "development",
       "processing_ms": 4479,
       "response_size": 135,
       "response_time": 56,
+      "result": "HTTP_CLIENT_ERROR",
+      "result_class": "WARNING",
+      "result_id": "agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA",
+      "result_url": " https://client.apimetrics.io/tests/result/agxkZXZ-dmlhdGVzdHNyGAsSC1Rlc3RSZXN1bHQzGICAgICAgPgJDA/",
       "ssl_handshake_ms": 222,
+      "start_time": "2026-04-01T00:00:00.000000Z",
+      "timing_data": {
+        "connect": 1,
+        "dns": 2,
+        "download": 13522,
+        "processing": 118,
+        "tls_handshake": 234,
+        "upload": 0
+      },
+      "upload_ms": 333,
+      "workflow_id": null,
       "workflow_result_id": null,
-      "workflow_result_url": null
-    }
+      "workflow_result_url": null,
+      "workflow_url": null
+    },
+    "sql_transform": "SELECT \narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(metadataTagsString))) AS metadataTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(projectMetaTagsString))) AS projectMetaTags,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextOwnersString))) AS contextOwners,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextReferencesString))) AS contextReferences,\narrayMap(x -> REPLACE(x, '\\\"', ''), \nJSONExtractArrayRaw(assumeNotNull(contextViewedString))) AS contextViewed,\n* FROM {STREAM}\n",
+    "wurfl": null
   },
   "type": "json"
 }

--- a/trafficpeak/apicontext/transformations/transform.json
+++ b/trafficpeak/apicontext/transformations/transform.json
@@ -3,7 +3,6 @@
   "name": "default_context_logs",
   "settings": {
     "compression": "",
-    "data_mirroring_target": null,
     "format_details": {
       "flattening": {
         "active": false,


### PR DESCRIPTION
## Summary
- Import TrafficPeak APIContext 1.0.0 bundle into IDT
- Add portable CAC source, generated bundle assets, dashboards, summary table, and transform
- Uses apicontext as the raw table and apicontext_sampled_day as the dashboard summary table

## Validation
- Performance review: pass with live read-only MCP evidence on demo.trafficpeak.live
- CAC validation: bundle parsing, hdx/grafana structure consistency, compatibility, and extend resolution passed
- IDT pipeline: uv run --python 3.11 --with pyyaml python scripts/run_pipeline.py --bundle-dir trafficpeak/apicontext --config trafficpeak/apicontext/bundle-config.json --track full --skip-validate --verbose