### PR TITLE
fix: dictionary naming errors

### DIFF
--- a/src/hdx/shared_proj.rs
+++ b/src/hdx/shared_proj.rs
@@ -292,7 +292,7 @@ pub async fn check_and_create_shared_function(
 
         for func in existing {
             if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
-                if name == function_name {
+                if name == function_name || name == expected_name {
                     println!(
                         "  ✓ Shared function {} exists (as {})",
                         function_name, expected_name
@@ -421,7 +421,7 @@ pub async fn check_and_create_shared_dictionary(
 
                 for dict in existing {
                     if let Some(name) = dict.get("name").and_then(|n| n.as_str()) {
-                        if name == dictionary_name {
+                        if name == dictionary_name || name == expected_name {
                             println!(
                                 "  ✓ Shared dictionary {} exists (as {})",
                                 dictionary_name, expected_name


### PR DESCRIPTION
## Summary

- `check_and_create_shared_function`: also matches by prefixed name (e.g. `bundle_verification_my_func`) so already-existing resources aren't re-created
- `check_and_create_shared_dictionary`: same fix for dictionaries (e.g. `akamai_geoip_asn_blocks_ipv4`)

## Changes

- `src/hdx/shared_proj.rs` — two `name == expected_name` additions to the existing-resource check

## Test plan

- [ ] Run validator against a bundle with shared dictionaries already on the cluster — confirm no "files not found" error
- [ ] Run against a bundle with no shared resources — confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)