### PR TITLE
Switch bundle testing cluster to hdx-se-playpen

### DIFF
--- a/src/bin/cleanup.rs
+++ b/src/bin/cleanup.rs
@@ -16,10 +16,10 @@ use std::collections::HashSet;
 
 // const ORG_UUID_MARK: &str = "d867bf48-4281-4496-8432-a93aa989aae6";  // markeplace-dev
 // const ORG_UUID_SAND: &str = "b646d78a-5fb2-4d5f-afef-b705bf185174";  // partnersandbox
-const ORG_UUID: &str = "2b8cbbf8-dcb8-4c28-bd94-cb46147296d1"; // demo.aws.hydrolix.live
+const ORG_UUID: &str = "25a47323-9d41-40f7-b2a2-de3fe500135a"; // hdx-se-playpen.hydrolix.live
                                                                // const PROJ_UUID_MARK: &str = "67e79a3c-f7d6-4b33-a207-fef4579a3152";  // markeplace-dev cdn_test_project
                                                                // const PROJ_UUID_SAND: &str = "469dbd34-6f06-4dfe-8fd1-9adf82123ecf";  // partnersandbox
-const PROJ_UUID: &str = "6debffd1-3c88-4d5e-afc8-9e1a770f6a7a"; // demo.aws.hydrolix.live
+const PROJ_UUID: &str = "3338ec5e-39f5-496d-a36d-d0ae97216ecb"; // hdx-se-playpen.hydrolix.live
                                                                 //const PROJ_NAME: &str = "cdn_test_project";
 const PROJ_NAME: &str = "bundle_verification";
 

--- a/src/hdx/mod.rs
+++ b/src/hdx/mod.rs
@@ -14,10 +14,10 @@ use std::time::Duration;
 // These are static but not secret
 // const ORG_UUID_MARK: &str = "d867bf48-4281-4496-8432-a93aa989aae6";  // markeplace-dev
 // const ORG_UUID_SAND: &str = "b646d78a-5fb2-4d5f-afef-b705bf185174";  // partnersandbox
-const ORG_UUID: &str = "2b8cbbf8-dcb8-4c28-bd94-cb46147296d1"; // demo.aws.hydrolix.live
+const ORG_UUID: &str = "25a47323-9d41-40f7-b2a2-de3fe500135a"; // hdx-se-playpen.hydrolix.live
                                                                // const PROJ_UUID_MARK: &str = "67e79a3c-f7d6-4b33-a207-fef4579a3152";  //  markeplace-dev cdn_test_project
                                                                // const PROJ_UUID_SAND: &str = "469dbd34-6f06-4dfe-8fd1-9adf82123ecf";  // partnersandbox
-const PROJ_UUID: &str = "6debffd1-3c88-4d5e-afc8-9e1a770f6a7a"; // demo.aws.hydrolix.live
+const PROJ_UUID: &str = "3338ec5e-39f5-496d-a36d-d0ae97216ecb"; // hdx-se-playpen.hydrolix.live
                                                                 // const PROJ_NAME: &str = "cdn_test_project";
 const PROJ_NAME: &str = "bundle_verification";
 


### PR DESCRIPTION
## Changes

- `src/hdx/mod.rs` — update `ORG_UUID` and `PROJ_UUID` constants to point at `hdx-se-playpen.hydrolix.live` and its `bundle_verification` project.
- `src/bin/cleanup.rs` — same two constants, kept in sync with `mod.rs`.

## Why

`demo.aws.hydrolix.live` is no longer the bundle-testing target. Moving to `hdx-se-playpen.hydrolix.live` so local `cargo run -- --local` and the `cleanup` binary work against the right cluster when `BUNDLE_TESTING_CLUSTER` is set to playpen.

## Notes

- The per-run validator/deploy flow creates a temporary project and stores its UUID in `GUID_PROJECT_UUID`; `get_project_uuid()` only falls back to `PROJ_UUID` when that isn't set.
- `dependencies::exist()` (`src/hdx/dependencies.rs`) still queries `PROJ_UUID` directly. The `bundle_verification` project has been created on playpen but is empty — any bundle with declared `required_functions` / `required_dictionaries` will need those synced via `scripts/sync_cluster_deps.py` before the dep-check passes.

## Test plan

- [ ] `BUNDLE_TESTING_CLUSTER=hdx-se-playpen.hydrolix.live cargo run -- --local <bundle>` reaches the playpen cluster
- [ ] Sync any required deps for the target bundle into playpen's `bundle_verification` project, then re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)