### PR TITLE
Update china_cdn portables with UID template variable cleanup

### DIFF
--- a/portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_dashboard_default.json
+++ b/portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_dashboard_default.json
@@ -82,14 +82,7 @@
       "name": "VAR_RAW_LOGS",
       "type": "constant",
       "label": "raw_logs",
-      "value": "UUID_HERE/NAME",
-      "description": ""
-    },
-    {
-      "name": "VAR_CDN_PANEL",
-      "type": "constant",
-      "label": "cdn_panel",
-      "value": "UUID_HERE/NAME",
+      "value": "__DASHBOARD_UID_RAW_LOGS__/raw-logs",
       "description": ""
     }
   ],
@@ -4077,25 +4070,6 @@
           {
             "value": "${VAR_RAW_LOGS}",
             "text": "${VAR_RAW_LOGS}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "hide": 2,
-        "name": "cdn_panel",
-        "query": "${VAR_CDN_PANEL}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_CDN_PANEL}",
-          "text": "${VAR_CDN_PANEL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_CDN_PANEL}",
-            "text": "${VAR_CDN_PANEL}",
             "selected": false
           }
         ]

--- a/portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_global_view.json
+++ b/portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_global_view.json
@@ -33,14 +33,14 @@
       "name": "VAR_RAW_LOGS",
       "type": "constant",
       "label": "raw_logs",
-      "value": "UUID_HERE/raw-logs",
+      "value": "__DASHBOARD_UID_RAW_LOGS__/raw-logs",
       "description": ""
     },
     {
       "name": "VAR_CDN_PANEL",
       "type": "constant",
       "label": "cdn_panel",
-      "value": "UUID_HERE/cdn-dashboard-default-v1-0-5",
+      "value": "__DASHBOARD_UID_CDN_DASHBOARD_DEFAULT__/cdn-dashboard-default",
       "description": ""
     }
   ],
@@ -145,7 +145,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "\n${drill_chain_for_display:text}\n\n💡 *Use the \"Customize \"Drilldown Path\" Order\" dropdown above to change the drilldown order of the dimensions.*",
+        "content": "\n${drill_chain_for_display:text}\n\n\ud83d\udca1 *Use the \"Customize \"Drilldown Path\" Order\" dropdown above to change the drilldown order of the dimensions.*",
         "mode": "markdown"
       },
       "pluginVersion": "12.0.0",
@@ -175,7 +175,7 @@
             {
               "targetBlank": true,
               "title": "Filter to RAW logs",
-              "url": "d/${raw_logs}?${__all_variables}﻿﻿﻿﻿﻿﻿﻿&﻿${__url_time_range}﻿﻿﻿﻿﻿﻿﻿&var-filter=﻿${next_dim}﻿|=|﻿${__data.fields.filter_item}"
+              "url": "d/${raw_logs}?${__all_variables}\ufeff\ufeff\ufeff\ufeff\ufeff\ufeff\ufeff&\ufeff${__url_time_range}\ufeff\ufeff\ufeff\ufeff\ufeff\ufeff\ufeff&var-filter=\ufeff${next_dim}\ufeff|=|\ufeff${__data.fields.filter_item}"
             }
           ],
           "mappings": [],
@@ -2025,11 +2025,11 @@
       {
         "allowCustomValue": false,
         "current": {},
-        "definition": "WITH map(\n    'hdx_cdn', 'CDN',\n    'asn', 'ASN',\n    'reqHost', 'Hostname',\n    'Edge_GeoInfo', 'Edge pop'\n) AS display_name_map\nSELECT arrayStringConcat(\n    arrayMap(\n        x -> if(x = '${next_dim}',\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #3787F3; color: white; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>'),\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #202226; border: 1px solid #333740; color: #9FA9B8; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>')\n        ),\n        ${drill_chain}\n    ),\n    ' <span style=\"color:#565a64;\">→</span> '\n)",
+        "definition": "WITH map(\n    'hdx_cdn', 'CDN',\n    'asn', 'ASN',\n    'reqHost', 'Hostname',\n    'Edge_GeoInfo', 'Edge pop'\n) AS display_name_map\nSELECT arrayStringConcat(\n    arrayMap(\n        x -> if(x = '${next_dim}',\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #3787F3; color: white; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>'),\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #202226; border: 1px solid #333740; color: #9FA9B8; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>')\n        ),\n        ${drill_chain}\n    ),\n    ' <span style=\"color:#565a64;\">\u2192</span> '\n)",
         "hide": 2,
         "name": "drill_chain_for_display",
         "options": [],
-        "query": "WITH map(\n    'hdx_cdn', 'CDN',\n    'asn', 'ASN',\n    'reqHost', 'Hostname',\n    'Edge_GeoInfo', 'Edge pop'\n) AS display_name_map\nSELECT arrayStringConcat(\n    arrayMap(\n        x -> if(x = '${next_dim}',\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #3787F3; color: white; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>'),\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #202226; border: 1px solid #333740; color: #9FA9B8; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>')\n        ),\n        ${drill_chain}\n    ),\n    ' <span style=\"color:#565a64;\">→</span> '\n)",
+        "query": "WITH map(\n    'hdx_cdn', 'CDN',\n    'asn', 'ASN',\n    'reqHost', 'Hostname',\n    'Edge_GeoInfo', 'Edge pop'\n) AS display_name_map\nSELECT arrayStringConcat(\n    arrayMap(\n        x -> if(x = '${next_dim}',\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #3787F3; color: white; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>'),\n                concat('<span style=\"display: inline-block; vertical-align: middle; background-color: #202226; border: 1px solid #333740; color: #9FA9B8; padding: 3px 8px; border-radius: 4px;\">', display_name_map[x], '</span>')\n        ),\n        ${drill_chain}\n    ),\n    ' <span style=\"color:#565a64;\">\u2192</span> '\n)",
         "refresh": 1,
         "regex": "",
         "type": "query"

--- a/portables/trafficpeak/china_cdn/1.0.0/grafana/resources.gfo.yaml
+++ b/portables/trafficpeak/china_cdn/1.0.0/grafana/resources.gfo.yaml
@@ -29,8 +29,7 @@ dashboards:
       VAR_QUANTILES_ORIGIN_TTFB_95: quantiles_origin_ttfb_ms[5]
       VAR_QUANTILES_ORIGIN_TTLB_50: quantiles_origin_ttlb_ms[2]
       VAR_QUANTILES_ORIGIN_TTLB_95: quantiles_origin_ttlb_ms[5]
-      VAR_RAW_LOGS: UUID_HERE/NAME
-      VAR_CDN_PANEL: UUID_HERE/NAME
+      VAR_RAW_LOGS: __DASHBOARD_UID_RAW_LOGS__/raw-logs
   hdx-cdn-global-view:
     dashboard:
       __extend__: dashboards/cdn_global_view.json
@@ -40,5 +39,5 @@ dashboards:
       VAR_SUMMARY_MIN: PROJECT.multi_summary_min
       VAR_SUMMARY_HOUR: PROJECT.multi_summary_hour
       VAR_CDN1: Akamai
-      VAR_RAW_LOGS: UUID_HERE/raw-logs
-      VAR_CDN_PANEL: UUID_HERE/cdn-dashboard-default-v1-0-5
+      VAR_RAW_LOGS: __DASHBOARD_UID_RAW_LOGS__/raw-logs
+      VAR_CDN_PANEL: __DASHBOARD_UID_CDN_DASHBOARD_DEFAULT__/cdn-dashboard-default


### PR DESCRIPTION
## Summary

- Replaces `UUID_HERE` placeholder strings in portable dashboards with proper `__DASHBOARD_UID_*__` template variables
- Removes `VAR_CDN_PANEL` from `cdn_dashboard_default` inputs (the `cdn_panel` variable was dropped in the source dashboard in #229)
- Updates `resources.gfo.yaml` inputs mapping for both `hdx-cdn-dashboard-default` and `hdx-cdn-global-view`

Portable files updated:
- `portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_dashboard_default.json`
- `portables/trafficpeak/china_cdn/1.0.0/grafana/dashboards/cdn_global_view.json`
- `portables/trafficpeak/china_cdn/1.0.0/grafana/resources.gfo.yaml`

Companion to #229. Merging this PR will trigger `push-to-cac-tools` to sync the updated `china_cdn` bundle to cac-tools.

## Test plan
- [ ] CI validate-only passes
- [ ] Merge triggers push-to-cac-tools and a PR appears in cac-tools with `china_cdn` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)