### PR TITLE
cdn-insights: remove stream_prefix override from bundle.json

### DIFF
--- a/aws/cdn-insights/bundle.json
+++ b/aws/cdn-insights/bundle.json
@@ -28,8 +28,7 @@
   },
   "method": "multi_stream",
   "method_overrides": {
-    "region": "us-east-1",
-    "stream_prefix": "aws-waf-logs-hdx"
+    "region": "us-east-1"
   },
   "name": "aws_cdn_insights",
   "other_dashboards": [
@@ -68,29 +67,29 @@
       "name": "logs",
       "transforms": [
         {
+          "method": "http_streaming",
           "path": "transformations/akamai_ds2/transform.json",
-          "sample": "transformations/akamai_ds2/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/akamai_ds2/sample_data.json"
         },
         {
+          "method": "http_streaming",
           "path": "transformations/cloudflare/transform.json",
-          "sample": "transformations/cloudflare/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/cloudflare/sample_data.json"
         },
         {
+          "method": "firehose",
           "path": "transformations/cloudfront_firehose/transform.json",
-          "sample": "transformations/cloudfront_firehose/sample_data.json",
-          "method": "firehose"
+          "sample": "transformations/cloudfront_firehose/sample_data.json"
         },
         {
+          "method": "http_streaming",
           "path": "transformations/fastly/transform.json",
-          "sample": "transformations/fastly/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/fastly/sample_data.json"
         },
         {
+          "method": "http_streaming",
           "path": "transformations/tencent/transform.json",
-          "sample": "transformations/tencent/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/tencent/sample_data.json"
         }
       ]
     }


### PR DESCRIPTION
## Changes

`aws/cdn-insights/bundle.json`

- Remove `"stream_prefix": "aws-waf-logs-hdx"` from `method_overrides`. This is a multi-CDN bundle (akamai, cloudflare, cloudfront, fastly, tencent) — a WAF-specific stream prefix doesn't belong here. The remaining override (`region: us-east-1`) is retained for the CloudFront firehose stream.
- Pre-commit `pretty-format-json` hook also alphabetized keys within each transform entry under `streams[0].transforms` (no semantic change).

Note: branch name is a holdover from PR #230 (already merged). This is a separate, unrelated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)