### PR TITLE
LOTC-1712: bump ephemeral test table max_age_days to 3650

### DIFF
--- a/src/deploy/default.rs
+++ b/src/deploy/default.rs
@@ -515,8 +515,9 @@ async fn verify_rows_ingested_if_present(
         async move { hdx::table::query_sql(&bearer, &sql).await }
     };
 
-    // Matches the hardcoded age in hdx::table::create.
-    let table_settings = serde_json::json!({ "age": { "max_age_days": 1 } });
+    let table_settings = serde_json::json!({
+        "age": { "max_age_days": hdx::table::TEST_TABLE_MAX_AGE_DAYS }
+    });
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/src/hdx/table.rs
+++ b/src/hdx/table.rs
@@ -4,6 +4,13 @@ use tokio::time::sleep;
 use tokio::time::Duration;
 use uuid::Uuid;
 
+/// `max_age_days` for the ephemeral table created during bundle validation.
+/// Set far in the future so committed `sample_data.json` fixtures with frozen
+/// primary-timestamp epochs don't age out on ingest. The zero-rows post-ingest
+/// check still catches genuine ingest failures; this only neutralizes fixture
+/// drift, which has no business being a validator gate.
+pub const TEST_TABLE_MAX_AGE_DAYS: u64 = 3650;
+
 pub async fn exists(bearer_token: &str, table_name: &str) -> Result<(), String> {
     let url = format!(
         "https://{}/config/v1/orgs/{}/projects/{}/tables",
@@ -84,7 +91,7 @@ pub async fn create_in_project(
         "name": table_name,
         "description": "testing",
         "settings": {
-            "age": { "max_age_days": 1 },
+            "age": { "max_age_days": TEST_TABLE_MAX_AGE_DAYS },
             "merge": { "enabled": false }
         }
     });
@@ -166,7 +173,7 @@ pub async fn create(bearer_token: &str, table_name: &str) -> Result<String, Stri
                 "description": "testing",
                 "settings": {
                     "age": {
-                        "max_age_days": 1
+                        "max_age_days": TEST_TABLE_MAX_AGE_DAYS
                     },
                     "merge": {
                         "enabled": false
@@ -184,7 +191,7 @@ pub async fn create(bearer_token: &str, table_name: &str) -> Result<String, Stri
                 "description": "testing",
                 "settings": {
                     "age": {
-                        "max_age_days": 1
+                        "max_age_days": TEST_TABLE_MAX_AGE_DAYS
                     },
                     "merge": {
                         "enabled": false


### PR DESCRIPTION
## Summary
- Bump `max_age_days` on the validator's per-bundle ephemeral test table from `1` to `3650` (10 years), centralized as `TEST_TABLE_MAX_AGE_DAYS` in `src/hdx/table.rs` and reused by the staleness diagnostic in `src/deploy/default.rs` so the two can't drift apart.
- Stops fixture rows from aging out on ingest just because their committed `reqTimeSec` literal is more than 24h stale. The `PRIMARY TIMESTAMP STALE` diagnostic was the *only* reason a number of bundles (`aws/bot-insights`, recently freshened in [3f37a72](https://github.com/hydrolix/integration-deployment-templates/commit/3f37a72)) were locally failing — and it was masking other real ingest issues underneath.
- Verified on `hdx-se-playpen`: `aws/bot-insights` `akamai_ds2` now ingests cleanly (`✓ Verified 1 row(s) queryable`). The bundle's other transforms surfaced separate issues tracked in [LOTC-1718](https://hydrolix.atlassian.net/browse/LOTC-1718) (out of scope here).

## Why this is OK
- Test table lives minutes then gets dropped; there's no production reason for a 1-day TTL on it.
- The staleness *diagnostic* (`src/deploy/verify.rs::diagnose_zero_rows`) is unchanged and its unit tests still pass — they pass `max_age_days: 1` explicitly via `table_settings`, decoupled from the production constant.
- The zero-rows post-ingest gate (`src/deploy/default.rs::verify_rows_ingested_if_present`) still catches real ingest failures (rows silently dropped despite HTTP 2xx from `/ingest/event`).

## Test plan
- [x] `cargo build` — clean.
- [x] `cargo test` — 74 unit tests pass, including all 21 `deploy::verify::tests::*` (staleness diagnostic tests).
- [x] `cargo run -- bot_insights --local --guid` against `hdx-se-playpen`: `akamai_ds2` row landed and was queryable (was failing on `PRIMARY TIMESTAMP STALE` on `main`).
- [ ] CI: full bundle validation matrix.

## Note on pre-commit hooks
Committed with `--no-verify` (user-authorized). Pre-existing `cargo fmt --check` and `cargo clippy -D warnings` failures on `main` block any commit — none of them are in files touched by this PR. Worth a separate cleanup pass; not in scope here.

## Follow-up
- [LOTC-1718](https://hydrolix.atlassian.net/browse/LOTC-1718) — fixes two latent bundle bugs (trafficpeak/bot_insights_ds2 SQL `*`-collision + aws/bot-insights/cloudflare add_transform 4xx) uncovered by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOTC-1718]: https://hydrolix.atlassian.net/browse/LOTC-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOTC-1718]: https://hydrolix.atlassian.net/browse/LOTC-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ