### PR TITLE
LOTC-1716: sync aws/bot-insights transforms from cac-tools

### DIFF
--- a/aws/bot-insights/transformations/akamai_ds2/transform.json
+++ b/aws/bot-insights/transformations/akamai_ds2/transform.json
@@ -104,7 +104,7 @@
             ]
           },
           "suppress": false,
-          "type": "string"
+          "type": "int32"
         },
         "name": "response_status_code"
       },
@@ -305,21 +305,6 @@
           "type": "boolean"
         },
         "name": "is_bot_traffic"
-      },
-      {
-        "datatype": {
-          "default": null,
-          "format": null,
-          "index": true,
-          "resolution": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false,
-          "type": "string"
-        },
-        "name": "resource_category"
       },
       {
         "datatype": {
@@ -571,60 +556,62 @@
           "type": "map"
         },
         "name": "unknown"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resource_category"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ai_category"
       }
     ],
     "rate_limit": null,
     "sample_data": {
-      "UA": "Mozilla%2F5.0+%28Macintosh%3B+Intel+Mac+OS+X+10_15_7%29+AppleWebKit%2F605.1.15+Version%2F17.4+Safari%2F605.1.15",
-      "accLang": "en-US",
-      "billingRegion": "8",
-      "breadcrumbs": "//BC/%5Ba=23.12.41.20,c=g,k=0,l=1%5D",
-      "bytes": "24576",
-      "cacheStatus": "1",
-      "city": "SAN+FRANCISCO",
-      "cliIP": "73.162.10.44",
-      "cookie": "sessid=xyz987;prefs=hd%3D1",
+      "Asnum": "7922",
+      "UA": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.0.0 Mobile/15E148 Safari/604.1",
+      "breadcrumbs": "",
+      "cacheStatus": 1,
+      "city": "New Haven",
+      "cliIP": "73.142.98.77",
       "country": "US",
-      "cp": "123456",
-      "customField": "cdn_logs_v1",
-      "dnsLookupTimeMSec": "12",
-      "edgeIP": "23.50.40.171",
-      "errorCode": "",
-      "ewExecutionInfo": "",
-      "ewUsageInfo": "",
-      "lastByte": "1",
-      "maxAgeSec": "600",
-      "objSize": "524288",
-      "overheadBytes": "512",
-      "proto": "HTTPS",
-      "queryStr": "session_id=abc123&bitrate=4000000",
-      "range": "1048576-1572863",
-      "referer": "https%3A%2F%2Fwww.example.com%2Fwatch%3Fid%3D1234",
-      "reqEndTimeMSec": "85",
-      "reqHost": "vod.example.com",
-      "reqId": "a1b2c3d4e5f6a7b8",
+      "origin_ip": "52.75.0.13",
+      "queryStr": "",
+      "referer": "https://hydrolix.io",
+      "reqHost": "hydrolix.io",
       "reqMethod": "GET",
-      "reqPath": "assets/title_1234/video/segment_00042.ts",
-      "reqPort": "443",
-      "reqTimeSec": "1777291200",
-      "rspContentLen": "524288",
-      "rspContentType": "video/mp2t",
-      "securityRules": "",
-      "serverCountry": "US",
-      "state": "California",
-      "statusCode": "206",
-      "streamId": "98765",
-      "tlsOverheadTimeMSec": "3",
-      "tlsVersion": "TLSv1.3",
-      "totalBytes": "25088",
-      "transferTimeMSec": "60",
-      "turnAroundTimeMSec": "82",
-      "uncompressedSize": "524288",
-      "version": 1,
-      "xForwardedFor": "73.162.10.44"
+      "reqPath": "/hls/Crimson Arcade S03E08 — Garden Doors/multivariant.m3u8",
+      "reqTimeSec": 1777291200,
+      "rspContentType": "application/vnd.apple.mpegurl",
+      "statusCode": 200,
+      "timeToFirstByte": 83,
+      "totalBytes": 1268,
+      "transferTimeMSec": 199
     },
     "shadow_table": null,
-    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'k=([^,\\]]+)') as origin_time_to_last_byte_ms,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=g[^]]*\\])', 'n=([^,\\]]+)') as edge_pop,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'a=([^,\\]]+)') AS origin_ip,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'l=([^,\\]]+)') AS origin_time_to_first_byte_ms,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=g[^]]*\\])', 'a=([^,\\]]+)') as edge_ip,\nmultiIf(\ncacheStatus=1,1,\nbreadcrumbs IS NULL OR empty(breadcrumbs),0,\norigin_ip IS NULL OR empty(origin_ip) OR origin_ip = '127.0.0.1',1,0\n) AS cache_was_cached,\ndecodeURLComponent(assumeNotNull(queryStr)) AS request_query_string,\nconcat('/', assumeNotNull(request_path)) as request_path,\ndecodeURLComponent(assumeNotNull(referer)) AS request_referer,\ndecodeURLComponent(assumeNotNull(UA)) as user_agent,\nmultiIf(positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other')\nAS resource_category,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n * \nFROM {STREAM}",
+    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'k=([^,\\]]+)') as origin_time_to_last_byte_ms,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=g[^]]*\\])', 'n=([^,\\]]+)') as edge_pop,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'a=([^,\\]]+)') AS origin_ip,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=o[^]]*\\])', 'l=([^,\\]]+)') AS origin_time_to_first_byte_ms,\ncommons_breadcrumbs(breadcrumbs, '(\\[[^[]*c=g[^]]*\\])', 'a=([^,\\]]+)') as edge_ip,\nmultiIf(\ncacheStatus=1,1,\nbreadcrumbs IS NULL OR empty(breadcrumbs),0,\norigin_ip IS NULL OR empty(origin_ip) OR origin_ip = '127.0.0.1',1,0\n) AS cache_was_cached,\ndecodeURLComponent(assumeNotNull(queryStr)) AS request_query_string,\nconcat('/', assumeNotNull(request_path)) as request_path,\ndecodeURLComponent(assumeNotNull(referer)) AS request_referer,\ndecodeURLComponent(assumeNotNull(UA)) as user_agent,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\nmultiIf(\n    positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other'\n) AS resource_category,\ndictGet('commons_ua_cat_dict', 'ai_category', assumeNotNull(user_agent)) AS ai_category,\n * \nFROM {STREAM}",
     "wurfl": null
   },
   "type": "json"

--- a/aws/bot-insights/transformations/cloudflare/transform.json
+++ b/aws/bot-insights/transformations/cloudflare/transform.json
@@ -1,624 +1,12 @@
 {
-  "name": "cloudflare",
   "description": "Version v1.0",
+  "name": "cloudflare",
   "settings": {
-    "is_default": false,
-    "rate_limit": null,
-    "sql_transform": "SELECT \n    CASE\n        WHEN match(CAST(EdgeStartTimestamp AS String), '^[0-9]+$') THEN \n            toDateTime64(\n                CAST(EdgeStartTimestamp AS Int64) / 1000000000.0, 9\n            )\n            ELSE parseDateTimeBestEffort(EdgeStartTimestamp)\n    END AS timestamp,\n    datediff(s, timestamp, now64(3)) AS hdx_source_latency_sec,\n    datediff('millisecond', timestamp, edge_end_timestamp) AS response_time_to_last_byte_ms,\n    concat(edge_colo_code, '-', edge_colo_id) as edge_pop,\n    TRUE as cache_was_cached,\n    decodeURLComponent(queryString(request_full_path)) as request_query_string,\n    multiIf(positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other') AS resource_category,\n    'NONE' AS user_agent_category,\n    FALSE AS is_bot_traffic,\n    *\nFROM { STREAM }",
-    "null_values": [],
-    "sample_data": [
-      {
-        "ClientIP": "50.205.69.23",
-        "OriginIP": "52.75.0.2",
-        "ClientASN": 7922,
-        "ClientCity": "West Hartford",
-        "ClientState": "US",
-        "EdgeColoCode": "SJC",
-        "EdgeColoID": "962",
-        "EdgeServerIP": null,
-        "ClientCountry": "US",
-        "CacheCacheStatus": "hit",
-        "ClientRequestURI": "/hls/Midnight Archive S01E01 â Ghost Signal/1200k/segment000000.m4s",
-        "ClientRequestHost": [
-          "https:",
-          "",
-          "hydrolix.io"
-        ],
-        "ClientRequestPath": "/hls/Midnight Archive S01E01 â Ghost Signal/1200k/segment000000.m4s",
-        "EdgeResponseBytes": 840923,
-        "ClientRequestQuery": "",
-        "EdgeResponseStatus": 200,
-        "EdgeStartTimestamp": "2025-10-08T16:19:00Z",
-        "EdgeEndTimestamp": "2025-10-08T16:19:02.100Z",
-        "OriginResponseTime": 0,
-        "ClientRequestMethod": "GET",
-        "ClientRequestReferer": "https://cloudflare-media.hydrolix.io",
-        "EdgeTimeToFirstByteMs": 72,
-        "ClientRequestUserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
-        "EdgeResponseContentType": "video/mp4",
-        "OriginResponseDurationMs": 334,
-        "OriginResponseHeaderReceiveDurationMs": 0
-      },
-      {
-        "ClientIP": "50.205.69.23",
-        "OriginIP": "52.75.0.2",
-        "ClientASN": 7922,
-        "ClientCity": "West Hartford",
-        "ClientState": "US",
-        "EdgeColoCode": "SJC",
-        "EdgeColoID": "962",
-        "EdgeServerIP": null,
-        "ClientCountry": "US",
-        "CacheCacheStatus": "hit",
-        "ClientRequestURI": "/hls/Midnight Archive S01E01 â Ghost Signal/1200k/segment000000.m4s",
-        "ClientRequestHost": [
-          "https:",
-          "",
-          "hydrolix.io"
-        ],
-        "ClientRequestPath": "/hls/Midnight Archive S01E01 â Ghost Signal/1200k/segment000000.m4s",
-        "EdgeResponseBytes": 840923,
-        "ClientRequestQuery": "",
-        "EdgeResponseStatus": 200,
-        "EdgeStartTimestamp": 1764051339000000000,
-        "EdgeEndTimestamp": "2025-11-25T03:35:41.100Z",
-        "OriginResponseTime": 0,
-        "ClientRequestMethod": "GET",
-        "ClientRequestReferer": "https://cloudflare-media.hydrolix.io",
-        "EdgeTimeToFirstByteMs": 72,
-        "ClientRequestUserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
-        "EdgeResponseContentType": "video/mp4",
-        "OriginResponseDurationMs": 334,
-        "OriginResponseHeaderReceiveDurationMs": 0
-      }
-    ],
-    "shadow_table": null,
-    "output_columns": [
-      {
-        "name": "result_type",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "CacheCacheStatus"
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "cache_was_cached",
-        "datatype": {
-          "type": "boolean",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "response_total_bytes",
-        "datatype": {
-          "type": "uint64",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeResponseBytes"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "response_status_code",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeResponseStatus"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "response_time_to_first_byte_ms",
-        "datatype": {
-          "type": "uint64",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeTimeToFirstByteMs"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "response_time_to_last_byte_ms",
-        "datatype": {
-          "type": "uint64",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "response_content_type",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeResponseContentType"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "request_method",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestMethod"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "request_host",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestHost"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "request_full_path",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestURI"
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "request_query_string",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "request_referer",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestReferer"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "request_path",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestPath"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "is_bot_traffic",
-        "datatype": {
-          "type": "boolean",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "resource_category",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "user_agent_category",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "user_agent",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientRequestUserAgent"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "client_ip",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientIP"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "edge_ip",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeServerIP"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "origin_ip",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "OriginIP"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "origin_time_to_first_byte_ms",
-        "datatype": {
-          "type": "uint64",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "OriginResponseHeaderReceiveDurationMs"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "origin_time_to_last_byte_ms",
-        "datatype": {
-          "type": "uint64",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "OriginResponseDurationMs"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "client_country_iso_code",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientCountry"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "client_city",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientCity"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "client_asn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "ClientASN"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "edge_colo_code",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeColoCode"
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "edge_colo_id",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeColoID"
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "edge_pop",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "hdx_source_latency_sec",
-        "datatype": {
-          "type": "uint32",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "hdx_cdn",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": "Cloudflare",
-          "script": null,
-          "source": null,
-          "suppress": false
-        }
-      },
-      {
-        "name": "hdx_transform",
-        "datatype": {
-          "type": "string",
-          "index": true,
-          "format": null,
-          "resolution": null,
-          "default": "Cloudflare multi cdn",
-          "script": null,
-          "source": null,
-          "suppress": false
-        }
-      },
-      {
-        "name": "unknown",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "catch_all": true,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": null,
-          "suppress": false
-        }
-      },
-      {
-        "name": "timestamp",
-        "datatype": {
-          "type": "datetime",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": true,
-          "ignore": false,
-          "format": "2006-01-02T15:04:05.999Z",
-          "resolution": "ms",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false
-        }
-      },
-      {
-        "name": "EdgeStartTimestamp",
-        "datatype": {
-          "type": "string",
-          "index": false,
-          "index_options": {
-            "fulltext": false
-          },
-          "primary": false,
-          "ignore": false,
-          "format": null,
-          "resolution": null,
-          "default": null,
-          "script": null,
-          "source": null,
-          "suppress": true
-        }
-      },
-      {
-        "name": "edge_end_timestamp",
-        "datatype": {
-          "type": "datetime",
-          "index": false,
-          "primary": false,
-          "format": "2006-01-02T15:04:05.999Z",
-          "resolution": "ms",
-          "default": null,
-          "script": null,
-          "source": {
-            "from_input_field": "EdgeEndTimestamp"
-          },
-          "suppress": true
-        }
-      }
-    ],
     "compression": "",
-    "wurfl": null,
     "format_details": {
       "flattening": {
         "active": false,
+        "depth": null,
         "map_flattening_strategy": {
           "left": "",
           "right": ""
@@ -626,10 +14,581 @@
         "slice_flattening_strategy": {
           "left": "",
           "right": ""
-        },
-        "depth": null
+        }
       }
-    }
+    },
+    "is_default": false,
+    "null_values": [],
+    "output_columns": [
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999Z",
+          "index": false,
+          "primary": true,
+          "resolution": "ms",
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeStartTimestamp"
+          },
+          "suppress": false,
+          "type": "datetime"
+        },
+        "name": "timestamp"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": "2006-01-02T15:04:05.999Z",
+          "index": false,
+          "primary": false,
+          "resolution": "ms",
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeEndTimestamp"
+          },
+          "suppress": true,
+          "type": "datetime"
+        },
+        "name": "edge_end_timestamp"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "CacheCacheStatus"
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "result_type"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "boolean"
+        },
+        "name": "cache_was_cached"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeResponseBytes"
+          },
+          "suppress": false,
+          "type": "uint64"
+        },
+        "name": "response_total_bytes"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeResponseStatus"
+          },
+          "suppress": false,
+          "type": "int32"
+        },
+        "name": "response_status_code"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeTimeToFirstByteMs"
+          },
+          "suppress": false,
+          "type": "uint64"
+        },
+        "name": "response_time_to_first_byte_ms"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "uint64"
+        },
+        "name": "response_time_to_last_byte_ms"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeResponseContentType"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "response_content_type"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestMethod"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "request_method"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestHost"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "request_host"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestURI"
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "request_full_path"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "request_query_string"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestReferer"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "request_referer"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestPath"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "request_path"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "user_agent_category"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientRequestUserAgent"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "user_agent"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientIP"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "client_ip"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeServerIP"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "edge_ip"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "OriginIP"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "origin_ip"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "OriginResponseHeaderReceiveDurationMs"
+          },
+          "suppress": false,
+          "type": "uint64"
+        },
+        "name": "origin_time_to_first_byte_ms"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "OriginResponseDurationMs"
+          },
+          "suppress": false,
+          "type": "uint64"
+        },
+        "name": "origin_time_to_last_byte_ms"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientCountry"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "client_country_iso_code"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientCity"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "client_city"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "ClientASN"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "client_asn"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeColoCode"
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "edge_colo_code"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "EdgeColoID"
+          },
+          "suppress": true,
+          "type": "string"
+        },
+        "name": "edge_colo_id"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "edge_pop"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "uint32"
+        },
+        "name": "hdx_source_latency_sec"
+      },
+      {
+        "datatype": {
+          "default": "Cloudflare",
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": null,
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "hdx_cdn"
+      },
+      {
+        "datatype": {
+          "default": "Cloudflare multi cdn",
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": null,
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "hdx_transform"
+      },
+      {
+        "datatype": {
+          "catch_all": true,
+          "default": null,
+          "elements": [
+            {
+              "index": true,
+              "type": "string"
+            },
+            {
+              "index": true,
+              "type": "string"
+            }
+          ],
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": null,
+          "suppress": false,
+          "type": "map"
+        },
+        "name": "unknown"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "boolean"
+        },
+        "name": "is_bot_traffic"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resource_category"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ai_category"
+      }
+    ],
+    "rate_limit": null,
+    "sample_data": {
+      "CacheCacheStatus": "hit",
+      "ClientASN": 7922,
+      "ClientCity": "West Hartford",
+      "ClientCountry": "US",
+      "ClientIP": "50.205.69.23",
+      "ClientRequestHost": [
+        "https:",
+        "",
+        "hydrolix.io"
+      ],
+      "ClientRequestMethod": "GET",
+      "ClientRequestPath": "/hls/Midnight Archive S01E01 — Ghost Signal/1200k/segment000000.m4s",
+      "ClientRequestQuery": "",
+      "ClientRequestReferer": "https://cloudflare-media.hydrolix.io",
+      "ClientRequestURI": "/hls/Midnight Archive S01E01 — Ghost Signal/1200k/segment000000.m4s",
+      "ClientRequestUserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
+      "ClientState": "US",
+      "EdgeColoCode": "SJC",
+      "EdgeColoID": "962",
+      "EdgeEndTimestamp": "2025-10-08T16:19:02.100Z",
+      "EdgeResponseBytes": 840923,
+      "EdgeResponseContentType": "video/mp4",
+      "EdgeResponseStatus": 200,
+      "EdgeServerIP": null,
+      "EdgeStartTimestamp": "2025-10-08T16:19:00Z",
+      "EdgeTimeToFirstByteMs": 72,
+      "OriginIP": "52.75.0.2",
+      "OriginResponseDurationMs": 334,
+      "OriginResponseHeaderReceiveDurationMs": 0,
+      "OriginResponseTime": 0
+    },
+    "shadow_table": null,
+    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\ndatediff('millisecond', timestamp, edge_end_timestamp) AS response_time_to_last_byte_ms,\nconcat(edge_colo_code, '-', edge_colo_id) as edge_pop,\nresult_type IN ('hit', 'stale', 'revalidated', 'updating') as cache_was_cached,\ndecodeURLComponent(queryString(request_full_path)) as request_query_string,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\nmultiIf(\n    positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other'\n) AS resource_category,\ndictGet('commons_ua_cat_dict', 'ai_category', assumeNotNull(user_agent)) AS ai_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n*\n FROM {STREAM}",
+    "wurfl": null
   },
   "type": "json"
 }

--- a/aws/bot-insights/transformations/cloudfront_firehose/transform.json
+++ b/aws/bot-insights/transformations/cloudfront_firehose/transform.json
@@ -148,7 +148,7 @@
             "from_input_field": "sc-status"
           },
           "suppress": false,
-          "type": "string"
+          "type": "int32"
         },
         "name": "response_status_code"
       },
@@ -330,21 +330,6 @@
           "suppress": false,
           "type": "string"
         },
-        "name": "resource_category"
-      },
-      {
-        "datatype": {
-          "default": null,
-          "format": null,
-          "index": true,
-          "resolution": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false,
-          "type": "string"
-        },
         "name": "user_agent_category"
       },
       {
@@ -394,14 +379,14 @@
         "datatype": {
           "default": null,
           "format": null,
-          "index": true,
+          "index": false,
           "resolution": null,
           "script": null,
           "source": {
             "from_input_field": "origin-fbl"
           },
           "suppress": true,
-          "type": "uint64"
+          "type": "double"
         },
         "name": "origin_time_to_first_byte_sec"
       },
@@ -424,14 +409,14 @@
         "datatype": {
           "default": null,
           "format": null,
-          "index": true,
+          "index": false,
           "resolution": null,
           "script": null,
           "source": {
             "from_input_field": "origin-lbl"
           },
           "suppress": true,
-          "type": "uint64"
+          "type": "double"
         },
         "name": "origin_time_to_last_byte_sec"
       },
@@ -521,21 +506,6 @@
             "from_input_field": "sql_transform"
           },
           "suppress": false,
-          "type": "boolean"
-        },
-        "name": "is_bot_traffic"
-      },
-      {
-        "datatype": {
-          "default": null,
-          "format": null,
-          "index": true,
-          "resolution": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false,
           "type": "uint32"
         },
         "name": "hdx_source_latency_sec"
@@ -589,23 +559,66 @@
           "type": "map"
         },
         "name": "unknown"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "boolean"
+        },
+        "name": "is_bot_traffic"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resource_category"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ai_category"
       }
     ],
     "rate_limit": null,
     "sample_data": {
       "records": [
         {
-          "data": "eyJ4LWVkZ2UtbG9jYXRpb24iOiJXQVc1MS1QMSIsInNjLWJ5dGVzIjoiMTAyMyIsImMtaXAiOiIxNzguNDMuMjQzLjQ2IiwiY3MtbWV0aG9kIjoiR0VUIiwiY3MoSG9zdCkiOiJkcmRsNXJ4MGFlNjNnLmNsb3VkZnJvbnQubmV0IiwiY3MtdXJpLXN0ZW0iOiIvIiwic2Mtc3RhdHVzIjoiMjAwIiwiY3MoUmVmZXJlcikiOiItIiwiY3MoVXNlci1BZ2VudCkiOiJNb3ppbGxhLzUuMCUyMChNYWNpbnRvc2g7JTIwSW50ZWwlMjBNYWMlMjBPUyUyMFglMjAxMF8xNV83KSUyMEFwcGxlV2ViS2l0LzUzNy4zNiUyMChLSFRNTCwlMjBsaWtlJTIwR2Vja28pJTIwQ2hyb21lLzEzNi4wLjAuMCUyMFNhZmFyaS81MzcuMzYiLCJjcy11cmktcXVlcnkiOiJ3aG89a2FtaWwiLCJjcyhDb29raWUpIjoiLSIsIngtZWRnZS1yZXN1bHQtdHlwZSI6IlJlZnJlc2hIaXQiLCJ4LWVkZ2UtcmVxdWVzdC1pZCI6IkowUmR6NndPd25tckV0Q1RlUmRzQTAyQXdRbmJ6TzNhOWJEcENHV0ZNZ2VlVDF1bnBFRTZQQT09IiwieC1ob3N0LWhlYWRlciI6ImRyZGw1cngwYWU2M2cuY2xvdWRmcm9udC5uZXQiLCJjcy1wcm90b2NvbCI6Imh0dHBzIiwiY3MtYnl0ZXMiOiI1MDMiLCJ0aW1lLXRha2VuIjoiMC41MTkiLCJ4LWZvcndhcmRlZC1mb3IiOiItIiwic3NsLXByb3RvY29sIjoiVExTdjEuMyIsInNzbC1jaXBoZXIiOiJUTFNfQUVTXzEyOF9HQ01fU0hBMjU2IiwieC1lZGdlLXJlc3BvbnNlLXJlc3VsdC10eXBlIjoiUmVmcmVzaEhpdCIsImNzLXByb3RvY29sLXZlcnNpb24iOiJIVFRQLzIuMCIsImZsZS1zdGF0dXMiOiItIiwiZmxlLWVuY3J5cHRlZC1maWVsZHMiOiItIiwiYy1wb3J0IjoiMjAyMDIiLCJ0aW1lLXRvLWZpcnN0LWJ5dGUiOiIwLjUxOSIsIngtZWRnZS1kZXRhaWxlZC1yZXN1bHQtdHlwZSI6IlJlZnJlc2hIaXQiLCJzYy1jb250ZW50LXR5cGUiOiJ0ZXh0L2h0bWwiLCJzYy1jb250ZW50LWxlbiI6IjY0OCIsInNjLXJhbmdlLXN0YXJ0IjoiLSIsInNjLXJhbmdlLWVuZCI6Ii0iLCJ0aW1lc3RhbXAiOiIxNzc3MjkxMjAwIn0="
+          "data": "ewogICJ4LWVkZ2UtbG9jYXRpb24iOiAiU0ZPNTMtUDkiLAogICJzYy1ieXRlcyI6ICI5OTI2MCIsCiAgImMtaXAiOiAiMjYwMToyMDY6ODEwMDoyYzpjODM3OjUxYzc6Y2RjZDplOTYxIiwKICAiY3MtbWV0aG9kIjogIkdFVCIsCiAgImNzKEhvc3QpIjogImQzbWU3dzU1ZDRmZmJjLmNsb3VkZnJvbnQubmV0IiwKICAiY3MtdXJpLXN0ZW0iOiAiL21lZGlhL3NlZ21lbnRfMTkyMHAxMDgwXzEyOS50cyIsCiAgInNjLXN0YXR1cyI6ICIyMDYiLAogICJjcyhSZWZlcmVyKSI6ICJodHRwczovL2JiYi1jbG91ZGZyb250LmhkeC1kZW1vLnVzLyIsCiAgImNzKFVzZXItQWdlbnQpIjogIk1vemlsbGEvNS4wJTIwKE1hY2ludG9zaDslMjBJbnRlbCUyME1hYyUyME9TJTIwWCUyMDEwXzE1XzcpJTIwQXBwbGVXZWJLaXQvNTM3LjM2JTIwKEtIVE1MLCUyMGxpa2UlMjBHZWNrbyklMjBDaHJvbWUvMTQyLjAuMC4wJTIwU2FmYXJpLzUzNy4zNiIsCiAgImNzLXVyaS1xdWVyeSI6ICItIiwKICAiY3MoQ29va2llKSI6ICItIiwKICAieC1lZGdlLXJlc3VsdC10eXBlIjogIkVycm9yIiwKICAieC1lZGdlLXJlcXVlc3QtaWQiOiAiSUhMSEdiZ2JGbHpOd1A4OVhCWE9rVjBQZ1FHVmZNdTRUM2Q5cmVGR0RCWjFoaHd2ajRnc1R3PT0iLAogICJ4LWhvc3QtaGVhZGVyIjogImJiYi1jbG91ZGZyb250LmhkeC1kZW1vLnVzIiwKICAiY3MtcHJvdG9jb2wiOiAiaHR0cHMiLAogICJjcy1ieXRlcyI6ICI0OSIsCiAgInRpbWUtdGFrZW4iOiAiMC40MTAiLAogICJ4LWZvcndhcmRlZC1mb3IiOiAiLSIsCiAgInNzbC1wcm90b2NvbCI6ICJUTFN2MS4zIiwKICAic3NsLWNpcGhlciI6ICJUTFNfQUVTXzEyOF9HQ01fU0hBMjU2IiwKICAieC1lZGdlLXJlc3BvbnNlLXJlc3VsdC10eXBlIjogIk1pc3MiLAogICJjcy1wcm90b2NvbC12ZXJzaW9uIjogIkhUVFAvMi4wIiwKICAiZmxlLXN0YXR1cyI6ICItIiwKICAiZmxlLWVuY3J5cHRlZC1maWVsZHMiOiAiLSIsCiAgImMtcG9ydCI6ICI1ODA2MCIsCiAgInRpbWUtdG8tZmlyc3QtYnl0ZSI6ICIwLjIzOSIsCiAgIngtZWRnZS1kZXRhaWxlZC1yZXN1bHQtdHlwZSI6ICJDbGllbnRDb21tRXJyb3IiLAogICJzYy1jb250ZW50LXR5cGUiOiAidmlkZW8vbXAydCIsCiAgInNjLWNvbnRlbnQtbGVuIjogIjI4MjcxNDQiLAogICJzYy1yYW5nZS1zdGFydCI6ICIwIiwKICAic2MtcmFuZ2UtZW5kIjogIjI4MjcxNDMiLAogICJ0aW1lc3RhbXAiOiAiMTc3NzI5MTIwMCIsCiAgImMtY291bnRyeSI6ICJVUyIKfQo="
         }
       ],
-      "requestId": "91e16ac6-6403-4f82-87ad-b87a0c248c4e",
+      "requestId": "f578af01-027d-4174-8c1b-e85b45809992",
       "timestamp": 1777291200000
     },
     "shadow_table": null,
-    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\npositionCaseInsensitive(result_type, 'hit') > 0 AS cache_was_cached,\nround(response_time_to_first_byte_sec * 1000) AS response_time_to_first_byte_ms,\nround(response_time_to_last_byte_sec * 1000) AS response_time_to_last_byte_ms,\nIF(isIPv6String(assumeNotNull(client_ip)), NULLIF(toString(dictGet('commons_geoip_asn_blocks_ipv6', 'autonomous_system_number', IPv6StringToNum(client_ip))),'0'), NULLIF(toString(dictGet('commons_geoip_asn_blocks_ipv4', 'autonomous_system_number', toIPv4(client_ip))),'0')) as client_asn,\norigin_time_to_first_byte_sec * 1000 AS origin_time_to_first_byte_ms,\norigin_time_to_last_byte_sec * 1000 AS origin_time_to_last_byte_ms,\n commons_city_name(client_ip) as client_city,\n multiIf(positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other')\nAS resource_category,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n * \nFROM {STREAM}",
+    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\npositionCaseInsensitive(result_type, 'hit') > 0 AS cache_was_cached,\nround(response_time_to_first_byte_sec * 1000) AS response_time_to_first_byte_ms,\nround(response_time_to_last_byte_sec * 1000) AS response_time_to_last_byte_ms,\nIF(isIPv6String(assumeNotNull(client_ip)), NULLIF(toString(dictGet('commons_geoip_asn_blocks_ipv6', 'autonomous_system_number', IPv6StringToNum(client_ip))),'0'), NULLIF(toString(dictGet('commons_geoip_asn_blocks_ipv4', 'autonomous_system_number', toIPv4(client_ip))),'0')) as client_asn,\nround(origin_time_to_first_byte_sec * 1000) AS origin_time_to_first_byte_ms,\nround(origin_time_to_last_byte_sec * 1000) AS origin_time_to_last_byte_ms,\n commons_city_name(client_ip) as client_city,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\nmultiIf(\n    positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other'\n) AS resource_category,\ndictGet('commons_ua_cat_dict', 'ai_category', assumeNotNull(user_agent)) AS ai_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n * \nFROM {STREAM}",
     "wurfl": null
   },
-  "table": "9cc3e26f-529a-4e73-80e2-7e3ee40c37eb",
-  "type": "json",
-  "url": "https://demo.aws.hydrolix.live/config/v1/orgs/2b8cbbf8-dcb8-4c28-bd94-cb46147296d1/projects/8e069469-e667-42fb-86d1-ddc8e6c6933a/tables/9cc3e26f-529a-4e73-80e2-7e3ee40c37eb/transforms/6f598f84-90ed-4ea4-ae79-96e8c2dc0269"
+  "type": "json"
 }

--- a/aws/bot-insights/transformations/default/transform.json
+++ b/aws/bot-insights/transformations/default/transform.json
@@ -69,7 +69,7 @@
           "script": null,
           "source": null,
           "suppress": false,
-          "type": "string"
+          "type": "int32"
         },
         "name": "response_status_code"
       },

--- a/aws/bot-insights/transformations/fastly/transform.json
+++ b/aws/bot-insights/transformations/fastly/transform.json
@@ -101,7 +101,7 @@
             ]
           },
           "suppress": false,
-          "type": "string"
+          "type": "int32"
         },
         "name": "response_status_code"
       },
@@ -287,36 +287,6 @@
           "type": "string"
         },
         "name": "request_path"
-      },
-      {
-        "datatype": {
-          "default": null,
-          "format": null,
-          "index": true,
-          "resolution": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false,
-          "type": "boolean"
-        },
-        "name": "is_bot_traffic"
-      },
-      {
-        "datatype": {
-          "default": null,
-          "format": null,
-          "index": true,
-          "resolution": null,
-          "script": null,
-          "source": {
-            "from_input_field": "sql_transform"
-          },
-          "suppress": false,
-          "type": "string"
-        },
-        "name": "resource_category"
       },
       {
         "datatype": {
@@ -567,37 +537,78 @@
           "type": "map"
         },
         "name": "unknown"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "boolean"
+        },
+        "name": "is_bot_traffic"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "resource_category"
+      },
+      {
+        "datatype": {
+          "default": null,
+          "format": null,
+          "index": true,
+          "resolution": null,
+          "script": null,
+          "source": {
+            "from_input_field": "sql_transform"
+          },
+          "suppress": false,
+          "type": "string"
+        },
+        "name": "ai_category"
       }
     ],
     "rate_limit": null,
     "sample_data": {
       "client_asn": "7922",
       "client_city": "yuba city",
-      "client_country_iso_code": "US",
-      "client_ip": "2601:206:8100:2c:f10e:a837:8244:9f7d",
-      "edge_ip": "2a04:4e42::498",
+      "client_country_iso_code": "USA",
+      "client_ip": "2601:206:8100:1339:f55d:fbd7:4873:884",
+      "edge_ip": "2a04:4e42:200::498",
       "edge_pop": "SJC",
-      "fastly_is_edge": true,
-      "fastly_server": "cache-sjc10051-SJC",
-      "host": "bbb-fastly.hdx-demo.us",
-      "origin_ip": "52.217.73.27",
+      "is_edge": true,
+      "origin_ip": "(null)",
+      "original_url": "/media/segment_1920p1080_015.ts",
+      "request_host": "bbb-fastly.hdx-demo.us",
       "request_method": "GET",
-      "request_protocol": "HTTP/2",
-      "request_referer": "https://bbb-fastly.hdx-demo.us/",
-      "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
-      "response_body_size": 2776196,
+      "request_referer": "https://bbb-fastly.hdx-demo.us/index.html",
       "response_content_type": "video/mp2t",
-      "response_reason": "Partial Content",
-      "response_state": "MISS-CLUSTER",
-      "response_status": 206,
-      "response_time_to_first_byte": 0.778,
-      "response_time_total": 0.781,
-      "response_total_bytes": 2776804,
+      "response_status_code": "200",
+      "response_time_to_first_byte": 0,
+      "response_time_to_last_byte": 0.003,
+      "response_total_bytes": 1831674,
+      "result_type": "HIT-CLUSTER",
       "timestamp": "2026-04-27T12:00:00",
-      "url": "/media/segment_1920p1080_035.ts"
+      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0.1 Safari/605.1.15"
     },
     "shadow_table": null,
-    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\nresponse_time_to_first_byte * 1000.0 as response_time_to_first_byte_ms,\nresponse_time_to_last_byte * 1000.0 as response_time_to_last_byte_ms,\npositionCaseInsensitive (result_type, 'hit') > 0 AS cache_was_cached,\nsplitByChar('?', assumeNotNull(original_url))[2] AS request_query_string,\nsplitByChar('?', assumeNotNull(original_url))[1] AS request_path,\nmultiIf(positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other')\nAS resource_category,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n * \nFROM {STREAM}",
+    "sql_transform": "SELECT datediff('s', timestamp, now64(3)) AS hdx_source_latency_sec,\nresponse_time_to_first_byte * 1000.0 as response_time_to_first_byte_ms,\nresponse_time_to_last_byte * 1000.0 as response_time_to_last_byte_ms,\npositionCaseInsensitive (result_type, 'hit') > 0 AS cache_was_cached,\nsplitByChar('?', assumeNotNull(original_url))[2] AS request_query_string,\nsplitByChar('?', assumeNotNull(original_url))[1] AS request_path,\ndictGet('commons_ua_cat_dict', 'ua_category', assumeNotNull(user_agent)) AS user_agent_category,\nmultiIf(\n    positionCaseInsensitive(assumeNotNull(request_path), 'robots.txt') > 0, 'robots.txt',\n    positionCaseInsensitive(assumeNotNull(request_path), 'llms.txt') > 0, 'llms.txt',\n    'other'\n) AS resource_category,\ndictGet('commons_ua_cat_dict', 'ai_category', assumeNotNull(user_agent)) AS ai_category,\ndictGet('commons_ua_cat_dict', 'is_bot', assumeNotNull(user_agent)) AS is_bot_traffic,\n * \nFROM {STREAM}",
     "wurfl": null
   },
   "type": "json"


### PR DESCRIPTION
## Summary

Syncs `aws/bot-insights` transforms with the upstream definitions in [cac-tools](https://github.com/hydrolix/cac-tools/tree/main/data/hydrolix/_defaults/integrations/solutions/native/bot_detection/transformations). Per [LOTC-1716](https://hydrolix.atlassian.net/browse/LOTC-1716): "Apply and Rebundle Bot Insights Direct Transform Changes to IDT."

## Changes

Only `transform.json` files were replaced. `sample_data.json` files, `bundle.json`, dashboards, summaries, and `tencent/` are intentionally untouched.

| File | What changed |
| --- | --- |
| `transformations/akamai_ds2/transform.json` | Replaced from cac-tools |
| `transformations/cloudflare/transform.json` | Replaced from cac-tools |
| `transformations/cloudfront_firehose/transform.json` | Replaced from cac-tools |
| `transformations/default/transform.json` | Replaced from cac-tools |
| `transformations/fastly/transform.json` | Replaced from cac-tools |

## Validation

- `cargo run -- bot_insights` — **SUCCESS** (with pre-existing benign warnings about `commons_*` dictionary references not appearing literally in `required_dictionaries`; they're declared as `shared_dictionaries` in `bundle.json`).

## Notes for reviewers

- `tencent/` was skipped intentionally (not listed in `bundle.json` transforms).
- `default/sample_data.json` was left as-is (no equivalent in cac-tools).
- A code review flagged two upstream-style observations (cac-tools `fastly` lacks `round()` around a `Float64 * 1000.0` → `uint64` cast; cac-tools `akamai_ds2` transform `name` is `"akamai"` while the directory is `akamai_ds2`). Both come from cac-tools as-is; fixing here would diverge from upstream and should be raised in the cac-tools repo instead.

## Test plan

- [ ] CI Track 2 validator passes
- [ ] Local `cargo run -- bot_insights` (done locally before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOTC-1716]: https://hydrolix.atlassian.net/browse/LOTC-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ