### PR TITLE
LOTC-2018..2025: fix bundle ui.primary_url doc links

### DIFF
--- a/aws/cdn-insights/bundle.json
+++ b/aws/cdn-insights/bundle.json
@@ -100,7 +100,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/cdn_insights-integration",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/solutions/cdn-insights/?h=cdn+in",
     "source": {
       "full_title": "CDN Insights",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/cdn_insights.png"

--- a/aws/cloudfront-to-kinesis/bundle.json
+++ b/aws/cloudfront-to-kinesis/bundle.json
@@ -49,7 +49,7 @@
       "full_title": "Amazon Kinesis",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/kinesis.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/Cloudfront.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-cloudfront/?h=cloudfr",
     "source": {
       "full_title": "Amazon CloudFront",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/cloudfront.png"

--- a/aws/firehose-datazoom-mediatailor/bundle.json
+++ b/aws/firehose-datazoom-mediatailor/bundle.json
@@ -32,7 +32,7 @@
       "full_title": "Amazon Data Firehose",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/firehose.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/ElementalMediaTailor.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-elemental-mediatailor/",
     "source": {
       "full_title": "AWS Elemental MediaTailor & DataZoom",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/mediatailor.png"

--- a/aws/firehose-medialive/bundle.json
+++ b/aws/firehose-medialive/bundle.json
@@ -42,7 +42,7 @@
       "full_title": "Amazon Data Firehose",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/firehose.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/ElementalMediaLive.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-elemental-medialive/",
     "source": {
       "full_title": "AWS Elemental MediaLive",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/medialive.png"

--- a/aws/firehose-mediapackage/bundle.json
+++ b/aws/firehose-mediapackage/bundle.json
@@ -52,7 +52,7 @@
       "full_title": "Amazon Data Firehose",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/firehose.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/ElementalMediaPackage.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-elemental-mediapackage/",
     "source": {
       "full_title": "AWS Elemental MediaPackage",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/mediapackage.jpeg"

--- a/aws/firehose-waf-global/bundle.json
+++ b/aws/firehose-waf-global/bundle.json
@@ -36,7 +36,7 @@
       "full_title": "Amazon Data Firehose",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/firehose.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/Waf.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-waf/",
     "source": {
       "full_title": "AWS WAF (Global for CloudFront)",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/waf.png"

--- a/aws/firehose-waf-regional/bundle.json
+++ b/aws/firehose-waf-regional/bundle.json
@@ -35,7 +35,7 @@
       "full_title": "Amazon Data Firehose",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/firehose.png"
     },
-    "primary_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/docs/Waf.html",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/aws/aws-waf/",
     "source": {
       "full_title": "AWS WAF (Regional)",
       "icon_url": "https://cascade-marketplace.s3.us-east-1.amazonaws.com/public/assets/icons/waf.png"

--- a/aws/zuplo/bundle.json
+++ b/aws/zuplo/bundle.json
@@ -32,7 +32,7 @@
       "full_title": "Http-Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/zuplo-integration",
+    "primary_url": "https://docs.hydrolix.io/latest/managed/data-sources/ingest-integrations/zuplo-integration/",
     "source": {
       "full_title": "Zuplo",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/zuplo.png"

--- a/trafficpeak/bot_insights_ds2/bundle.json
+++ b/trafficpeak/bot_insights_ds2/bundle.json
@@ -89,9 +89,9 @@
       "name": "logs",
       "transforms": [
         {
+          "method": "http_streaming",
           "path": "transformations/transform.json",
-          "sample": "transformations/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/sample_data.json"
         }
       ]
     }
@@ -102,7 +102,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/bot_insights_ds2-integration",
+    "primary_url": "https://techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview",
     "source": {
       "full_title": "Trafficpeak Bot Insights Ds2",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"

--- a/trafficpeak/china_cdn/bundle.json
+++ b/trafficpeak/china_cdn/bundle.json
@@ -80,7 +80,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/china_cdn-integration",
+    "primary_url": "https://techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview",
     "source": {
       "full_title": "Trafficpeak China CDN",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"

--- a/trafficpeak/default_shared/bundle.json
+++ b/trafficpeak/default_shared/bundle.json
@@ -94,7 +94,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/default_trafficpeak-integration",
+    "primary_url": "https://techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview",
     "source": {
       "full_title": "Trafficpeak",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"

--- a/trafficpeak/edns/bundle.json
+++ b/trafficpeak/edns/bundle.json
@@ -42,9 +42,9 @@
       "name": "edns",
       "transforms": [
         {
+          "method": "http_streaming",
           "path": "transformations/transform.json",
-          "sample": "transformations/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/sample_data.json"
         }
       ]
     }
@@ -55,7 +55,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/edns-integration",
+    "primary_url": "https://techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview",
     "source": {
       "full_title": "Trafficpeak Edns",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"

--- a/trafficpeak/mcdn/bundle.json
+++ b/trafficpeak/mcdn/bundle.json
@@ -64,19 +64,19 @@
       "name": "logs",
       "transforms": [
         {
+          "method": "http_streaming",
           "path": "transformations/tp_mcdn_cloudflare/transform.json",
-          "sample": "transformations/tp_mcdn_cloudflare/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/tp_mcdn_cloudflare/sample_data.json"
         },
         {
+          "method": "firehose",
           "path": "transformations/tp_mcdn_cloudfront_firehose/transform.json",
-          "sample": "transformations/tp_mcdn_cloudfront_firehose/sample_data.json",
-          "method": "firehose"
+          "sample": "transformations/tp_mcdn_cloudfront_firehose/sample_data.json"
         },
         {
+          "method": "http_streaming",
           "path": "transformations/tp_mcdn_fastly/transform.json",
-          "sample": "transformations/tp_mcdn_fastly/sample_data.json",
-          "method": "http_streaming"
+          "sample": "transformations/tp_mcdn_fastly/sample_data.json"
         }
       ]
     }
@@ -87,7 +87,7 @@
       "full_title": "Http Streaming",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/http.png"
     },
-    "primary_url": "https://docs.hydrolix.io/docs/mcdn-integration",
+    "primary_url": "https://techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview",
     "source": {
       "full_title": "Trafficpeak Mcdn",
       "icon_url": "https://hydrolix-public.s3.us-east-2.amazonaws.com/partner_logos/trafficpeak.png"


### PR DESCRIPTION
## Summary

Corrects the `ui.primary_url` documentation link in each bundle manifest so future `cmd/import-idt-bundles` re-imports into the console-go Postgres catalog stop carrying 404ing or stale links. (The dev console DB was corrected separately as a one-off; this fixes the source of truth.)

Covers tickets LOTC-2018 through LOTC-2025.

## Changes

| Ticket | Bundle(s) | New `ui.primary_url` |
|--------|-----------|----------------------|
| [LOTC-2018](https://hydrolix.atlassian.net/browse/LOTC-2018) | `aws/cdn-insights` | `…/latest/managed/solutions/cdn-insights/?h=cdn+in` |
| [LOTC-2019](https://hydrolix.atlassian.net/browse/LOTC-2019) | `aws/cloudfront-to-kinesis` | `…/latest/managed/data-sources/aws/aws-cloudfront/?h=cloudfr` |
| [LOTC-2020](https://hydrolix.atlassian.net/browse/LOTC-2020) | `aws/firehose-datazoom-mediatailor` | `…/aws/aws-elemental-mediatailor/` |
| [LOTC-2021](https://hydrolix.atlassian.net/browse/LOTC-2021) | `aws/firehose-medialive` | `…/aws/aws-elemental-medialive/` |
| [LOTC-2022](https://hydrolix.atlassian.net/browse/LOTC-2022) | `aws/firehose-mediapackage` | `…/aws/aws-elemental-mediapackage/` |
| [LOTC-2023](https://hydrolix.atlassian.net/browse/LOTC-2023) | `aws/firehose-waf-regional` + `aws/firehose-waf-global` | `…/aws/aws-waf/` |
| [LOTC-2024](https://hydrolix.atlassian.net/browse/LOTC-2024) | `trafficpeak/{bot_insights_ds2,china_cdn,default_shared,edns,mcdn}` | `techdocs.akamai.com/trafficpeak/docs/trafficpeak-overview` (interim) |
| [LOTC-2025](https://hydrolix.atlassian.net/browse/LOTC-2025) | `aws/zuplo` | `…/latest/managed/data-sources/ingest-integrations/zuplo-integration/` |

`trafficpeak/security` already pointed at the Akamai overview URL, so it was unchanged.

## Notes

- All 10 updated URLs were verified to resolve (HTTP 200, correct page titles) against the live docs sites.
- The diff on 3 trafficpeak bundles (`bot_insights_ds2`, `edns`, `mcdn`) includes cosmetic JSON key re-ordering applied automatically by the repo's `pretty-format-json` pre-commit hook — no value changes beyond `primary_url`.
- LOTC-2024 part 2 (authoring proper per-bundle TrafficPeak docs to replace the catch-all overview) is a separate follow-up; this PR applies the interim URL.
- Pre-existing, out-of-scope (flagged for a follow-up ticket): the stale `docs.hydrolix.io/docs/...-integration` URL template in `scripts/configurator/bundle_json_builder.py` and the example/templates in `BUNDLE-DETAILS.md` and the bundle-generation skills will still produce old-pattern links for *new* bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOTC-2018]: https://hydrolix.atlassian.net/browse/LOTC-2018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOTC-2019]: https://hydrolix.atlassian.net/browse/LOTC-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOTC-2020]: https://hydrolix.atlassian.net/browse/LOTC-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOTC-2021]: https://hydrolix.atlassian.net/browse/LOTC-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LOTC-2022]: https://hydrolix.atlassian.net/browse/LOTC-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ