### PR TITLE
LOTC-1963: set trafficpeak/default_shared channel_type to 3rdParty

### DIFF
--- a/trafficpeak/default_shared/bundle.json
+++ b/trafficpeak/default_shared/bundle.json
@@ -22,7 +22,7 @@
     }
   },
   "metadata": {
-    "channel_type": "AWS",
+    "channel_type": "3rdParty",
     "description": "Default shared configuration for Trafficpeak monitoring and analytics, providing insights into traffic patterns, performance metrics, and usage trends across your services.",
     "maintainer": "kevin.borkman@hydrolix.io",
     "version": "1.0.0"


### PR DESCRIPTION
## Summary

Fixes [LOTC-1963](https://hydrolix.atlassian.net/browse/LOTC-1963).

`trafficpeak/default_shared/bundle.json` was the only TrafficPeak bundle declaring `metadata.channel_type: "AWS"` — every other trafficpeak bundle (`bot_insights_ds2`, `china_cdn`, `edns`, `mcdn`, `security`) uses `"3rdParty"`. TrafficPeak is not an AWS integration, so `AWS` is incorrect.

## Impact

The console-go bundle importer (LOTC-1909) maps `metadata.channel_type` → the `bundles.cloud` column (`AWS` → `aws`, `3rdParty`/unknown → `any`). Because of this metadata error, `trafficpeak_default_shared` imported with `cloud = aws` while the other trafficpeak bundles correctly landed as `cloud = any` (the outlier in the 14/15 import dry-run). The importer faithfully reflects the source, so the fix belongs upstream in IDT.

## Change

- `trafficpeak/default_shared/bundle.json`: `metadata.channel_type` `"AWS"` → `"3rdParty"`

Re-run the importer afterward to pick up the corrected cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOTC-1963]: https://hydrolix.atlassian.net/browse/LOTC-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ