### PR TITLE
trafficpeak/edns: stop suppressing the answers column

### DIFF
--- a/trafficpeak/edns/transformations/transform.json
+++ b/trafficpeak/edns/transformations/transform.json
@@ -155,7 +155,7 @@
           "index": true,
           "script": null,
           "source": null,
-          "suppress": true,
+          "suppress": false,
           "type": "string"
         },
         "name": "answers"


### PR DESCRIPTION
## Summary

Aligns the IDT `trafficpeak/edns` transform with the published `trafficpeak.akamai_edns` bundle (gcloud `insights-artifacts`, v1.1.0).

In IDT, the `answers` output column was marked `suppress: true`, so it was excluded from storage. The packaged bundle keeps it (`suppress: false`). This flips IDT to match, retaining the DNS answer set.

## Change

- `trafficpeak/edns/transformations/transform.json` — `answers` column `datatype.suppress` `true` → `false`

## Context

Found while comparing the gcloud `akamai_edns:1.1.0` artifact against IDT. The two transforms were otherwise equivalent (same name, description, 20 columns in the same order, semantically identical `sql_transform`); the `answers` suppression was the only behavioral difference.

> Note: the gcloud build also annotates 5 SQL-derived columns (`answer`, `ttl`, `state`, `city`, `country`) with `source: {from_input_field: "sql_transform"}` where IDT has `source: null`. That's a provenance annotation with no functional effect and is intentionally left out of this PR, which is scoped to the `answers` suppression only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)