### PR TITLE
trafficpeak/edns: project-qualify summary table dashboard variable

### DIFF
--- a/trafficpeak/edns/dashboards/eDNS _ GTM.json
+++ b/trafficpeak/edns/dashboards/eDNS _ GTM.json
@@ -2069,8 +2069,8 @@
         {
           "current": {
             "selected": false,
-            "text": "__SUMMARY_TABLE_NAME_1__",
-            "value": "__SUMMARY_TABLE_NAME_1__"
+            "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+            "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
           },
           "description": "The name of the table which will be used for querying the dns data",
           "hide": 2,
@@ -2078,11 +2078,11 @@
           "options": [
             {
               "selected": false,
-              "text": "__SUMMARY_TABLE_NAME_1__",
-              "value": "__SUMMARY_TABLE_NAME_1__"
+              "text": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
+              "value": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__"
             }
           ],
-          "query": "__SUMMARY_TABLE_NAME_1__",
+          "query": "__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__",
           "skipUrlSync": true,
           "type": "constant"
         },


### PR DESCRIPTION
## Summary

In the eDNS / GTM dashboard, the summary-table selector variable was missing the `__PROJECT_NAME__` qualifier, so queries against the summary table weren't project-scoped like the raw-table queries (and like the other bundles).

## Root cause

The dashboard picks a table via a `table` variable:

```
CASE WHEN ${duration} <= 72 THEN '${edns}' ELSE '${edns_summary_hour}' END
```

- `edns` (raw)     → `__PROJECT_NAME__.__TABLE_NAME__`  ✅ project-qualified
- `edns_summary_hour` (summary) → `__SUMMARY_TABLE_NAME_1__`  ❌ no project

Panels then do `FROM ${table}`, so when the summary branch is selected the project qualifier was dropped.

## Change

- `trafficpeak/edns/dashboards/eDNS _ GTM.json` — `edns_summary_hour` constant variable (`current.text`, `current.value`, `options[].text`, `options[].value`, `query`) `__SUMMARY_TABLE_NAME_1__` → `__PROJECT_NAME__.__SUMMARY_TABLE_NAME_1__`

This makes the summary path consistent with the raw path within the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)