### PR TITLE
fix(ci): remediate Aikido script-injection finding — pass GitHub context to run steps via env

### DIFF
--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -189,9 +189,9 @@ jobs:
         run: pip install pyyaml
 
       - name: Format and configure bundles (Track 1)
+        env:
+          BUNDLE_DIRS: ${{ needs.detect-changes.outputs.full_pipeline_dirs }}
         run: |
-          BUNDLE_DIRS='${{ needs.detect-changes.outputs.full_pipeline_dirs }}'
-
           echo "$BUNDLE_DIRS" | jq -r '.[]' | while IFS= read -r bundle_dir; do
             echo ""
             echo "========================================="
@@ -349,13 +349,13 @@ jobs:
           GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
           DATABASE_URL: postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:5432/${{ secrets.DB_NAME }}
+          BUNDLE_NAME: ${{ github.event.inputs.bundle_name }}
+          PROJECT_NAME: ${{ github.event.inputs.project_name }}
+          N_ROWS: ${{ github.event.inputs.n_rows }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          BUNDLE_NAME="${{ github.event.inputs.bundle_name }}"
-          PROJECT_NAME="${{ github.event.inputs.project_name }}"
-          N_ROWS="${{ github.event.inputs.n_rows }}"
-
           if [ -z "$PROJECT_NAME" ]; then
-            PROJECT_NAME="ci_${BUNDLE_NAME}_${{ github.run_id }}"
+            PROJECT_NAME="ci_${BUNDLE_NAME}_${RUN_ID}"
           fi
           if [ -z "$N_ROWS" ]; then
             N_ROWS="10"

--- a/.github/workflows/bundle-request-alert.yml
+++ b/.github/workflows/bundle-request-alert.yml
@@ -26,16 +26,18 @@ jobs:
           aws-region: us-west-2
 
       - name: Load secrets from AWS Secrets Manager
+        env:
+          AWS_SECRET_ARN: ${{ vars.AWS_SECRET_ARN }}
         run: |
           secrets=$(aws secretsmanager get-secret-value \
-            --secret-id "${{ vars.AWS_SECRET_ARN }}" \
+            --secret-id "$AWS_SECRET_ARN" \
             --query SecretString \
             --output text)
 
           webhook_url=$(echo "$secrets" | python3 -c "import json,sys; print(json.load(sys.stdin).get('SLACK_WEBHOOK_URL', ''))")
 
           if [ -z "$webhook_url" ] || [ "$webhook_url" = "null" ]; then
-            echo "Error: SLACK_WEBHOOK_URL key not found in secret ${{ vars.AWS_SECRET_ARN }}" >&2
+            echo "Error: SLACK_WEBHOOK_URL key not found in secret $AWS_SECRET_ARN" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-runbook.yml
+++ b/.github/workflows/publish-runbook.yml
@@ -34,10 +34,11 @@ jobs:
 
       - name: Detect changed bundle directories
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BUNDLE_PATH: ${{ inputs.bundle_path }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BUNDLE_PATH="${{ inputs.bundle_path }}"
-
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ ! -f "$BUNDLE_PATH/bundle.json" ]; then
               echo "Error: bundle.json not found at $BUNDLE_PATH/bundle.json" >&2
               exit 1
@@ -99,9 +100,11 @@ jobs:
           aws-region: us-west-2
 
       - name: Load secrets from AWS Secrets Manager
+        env:
+          AWS_SECRET_ARN: ${{ vars.AWS_SECRET_ARN }}
         run: |
           secrets=$(aws secretsmanager get-secret-value \
-            --secret-id "${{ vars.AWS_SECRET_ARN }}" \
+            --secret-id "$AWS_SECRET_ARN" \
             --query SecretString \
             --output text)
 
@@ -119,9 +122,11 @@ jobs:
 
       - name: Generate runbook
         id: generate
+        env:
+          BUNDLE_DIR: ${{ matrix.bundle_dir }}
         run: |
           python scripts/generate_runbook.py \
-            --bundle-dir "${{ matrix.bundle_dir }}" \
+            --bundle-dir "$BUNDLE_DIR" \
             --output runbook.json
 
           BUNDLE_NAME=$(python -c "import json; d=json.load(open('runbook.json')); print(d['bundle_name'])")
@@ -138,7 +143,9 @@ jobs:
           echo "Published runbook to: $CONFLUENCE_URL"
 
       - name: Notify bundle team
+        env:
+          CONFLUENCE_URL: ${{ steps.publish.outputs.confluence_url }}
         run: |
           python scripts/notify_bundle_team.py \
             --runbook runbook.json \
-            --confluence-url "${{ steps.publish.outputs.confluence_url }}"
+            --confluence-url "$CONFLUENCE_URL"

--- a/.github/workflows/push-to-cac-tools-test.yml
+++ b/.github/workflows/push-to-cac-tools-test.yml
@@ -22,17 +22,22 @@ jobs:
       - name: Resolve PR context
         id: pr-context
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ github.event.inputs.pr_number }}"
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
           else
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            HEAD_SHA="$EVENT_HEAD_SHA"
           fi
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
 
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -90,9 +95,9 @@ jobs:
 
       - name: Export portables to CAC
         if: steps.detect-bundles.outputs.has_changes == 'true'
+        env:
+          PORTABLE_BUNDLES: ${{ steps.detect-bundles.outputs.portable_bundles }}
         run: |
-          PORTABLE_BUNDLES="${{ steps.detect-bundles.outputs.portable_bundles }}"
-
           echo "$PORTABLE_BUNDLES" | while IFS= read -r bundle_name; do
             if [ -n "$bundle_name" ] && [ -d "integrations-deployment-templates/portables/$bundle_name" ]; then
               echo "Copying portables/$bundle_name → cac-tools-test/data/bundles/$bundle_name/"
@@ -121,12 +126,7 @@ jobs:
             exit 0
           fi
 
-          PR_NUMBER="${{ steps.pr-context.outputs.pr_number }}"
-          COMMIT_SHA="${{ steps.pr-context.outputs.head_sha }}"
-          TRIGGERED_BY="${{ github.actor }}"
           TEST_PREFIX="[TEST] "
-
-          BUNDLE_LIST="${{ steps.detect-bundles.outputs.bundle_list }}"
 
           BRANCH_NAME="push-to-cac-tools-test-${PR_NUMBER}"
 
@@ -179,3 +179,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
+          COMMIT_SHA: ${{ steps.pr-context.outputs.head_sha }}
+          TRIGGERED_BY: ${{ github.actor }}
+          BUNDLE_LIST: ${{ steps.detect-bundles.outputs.bundle_list }}

--- a/.github/workflows/push-to-cac-tools.yml
+++ b/.github/workflows/push-to-cac-tools.yml
@@ -71,9 +71,9 @@ jobs:
 
       - name: Export portables to CAC
         if: steps.detect-bundles.outputs.has_changes == 'true'
+        env:
+          PORTABLE_BUNDLES: ${{ steps.detect-bundles.outputs.portable_bundles }}
         run: |
-          PORTABLE_BUNDLES="${{ steps.detect-bundles.outputs.portable_bundles }}"
-
           echo "$PORTABLE_BUNDLES" | while IFS= read -r bundle_name; do
             if [ -n "$bundle_name" ] && [ -d "integrations-deployment-templates/portables/$bundle_name" ]; then
               echo "Copying portables/$bundle_name → cac-tools/data/bundles/$bundle_name/"
@@ -102,19 +102,15 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            COMMIT_SHA="${{ github.sha }}"
-            TRIGGERED_BY="${{ github.event.pull_request.user.login }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            TRIGGERED_BY="$PR_AUTHOR"
             TEST_PREFIX=""
           else
-            PR_NUMBER="run-${{ github.run_id }}"
-            COMMIT_SHA="${{ github.sha }}"
-            TRIGGERED_BY="${{ github.actor }}"
+            PR_NUMBER="run-${RUN_ID}"
+            TRIGGERED_BY="$ACTOR"
             TEST_PREFIX="[TEST] "
           fi
-
-          BUNDLE_LIST="${{ steps.detect-bundles.outputs.bundle_list }}"
 
           BRANCH_NAME="push-to-cac-tools-${PR_NUMBER}-$(date +%s)"
           git checkout -b "$BRANCH_NAME"
@@ -140,7 +136,7 @@ jobs:
           **Source PR:** #${PR_NUMBER}
           **Source commit:** \`${COMMIT_SHA}\`
           **Triggered by:** @${TRIGGERED_BY}
-          **Trigger type:** ${{ github.event_name }}
+          **Trigger type:** ${EVENT_NAME}
 
           This PR was automatically generated to sync portable bundle changes from the integration-deployment-templates repository." \
             --base main \
@@ -149,3 +145,10 @@ jobs:
           echo "Successfully created PR in CAC repository"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          BUNDLE_LIST: ${{ steps.detect-bundles.outputs.bundle_list }}


### PR DESCRIPTION
Remediates the critical Aikido finding (GitHub Actions script injection, 20 subissues): workflow `run:` steps interpolated `${{ }}` GitHub context expressions directly into shell script text, so a value containing shell metacharacters would execute as code and could exfiltrate CI tokens.

Every such expression now enters the shell via a step-level `env:` block and is referenced as a quoted `"$VAR"`, so untrusted values are treated as data, not script. Verified with actionlint + a scan confirming zero `${{ }}` expressions remain inside any `run:` block.

## Changes

- `.github/workflows/bundle-ci.yml` — `workflow_dispatch` inputs (`bundle_name`, `project_name`, `n_rows`) and the `full_pipeline_dirs` job output (derived from PR file paths) moved to `env:` in the deploy and format steps.
- `.github/workflows/push-to-cac-tools-test.yml` — `inputs.pr_number`, PR event fields, `github.actor`, and the `portable_bundles`/`bundle_list` step outputs moved to `env:`.
- `.github/workflows/push-to-cac-tools.yml` — `pull_request.user.login`, `github.actor`, event fields, and bundle-list step outputs moved to `env:`.
- `.github/workflows/publish-runbook.yml` — `inputs.bundle_path`, `matrix.bundle_dir`, `confluence_url` step output, and `vars.AWS_SECRET_ARN` moved to `env:`.
- `.github/workflows/bundle-request-alert.yml` — `vars.AWS_SECRET_ARN` moved to `env:` (PR title/author were already safely passed via `env:`).

## Follow-ups noted in code review (pre-existing, out of scope)

- `bundle-ci.yml` deploy step splices free-text dispatch inputs into a `claude --dangerously-skip-permissions -p` prompt whose env holds cluster secrets — inputs should be allowlist-validated and secrets not restated in the prompt.
- `push-to-cac-tools-test.yml` runs `scripts/update_latest_versions.py` from the PR-head checkout on approval while holding the privileged App token (pwn-request pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)